### PR TITLE
fix: under certain conditions several copies of web-eid-app are launched

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1084,9 +1084,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.defaults": {

--- a/src/background/actions/TokenSigning/getCertificate.ts
+++ b/src/background/actions/TokenSigning/getCertificate.ts
@@ -39,9 +39,10 @@ export default async function getCertificate(
   lang?: string,
   filter: "AUTH" | "SIGN" = "SIGN",
 ): Promise<TokenSigningCertResponse | TokenSigningErrorResponse> {
+  const nativeAppService = new NativeAppService();
+
   try {
-    const nativeAppService = new NativeAppService();
-    const nativeAppStatus  = await nativeAppService.connect();
+    const nativeAppStatus = await nativeAppService.connect();
 
     console.log("Get certificate: connected to native", nativeAppStatus);
 
@@ -50,7 +51,7 @@ export default async function getCertificate(
         command: "get-certificate",
 
         arguments: {
-          "type":   filter.toLowerCase(),
+          "type":   filter.toLowerCase() as "sign" | "auth",
           "origin": (new URL(sourceUrl)).origin,
 
           // TODO: Implement i18n in native application
@@ -80,5 +81,7 @@ export default async function getCertificate(
   } catch (error) {
     console.error(error);
     return errorToResponse(nonce, error);
+  } finally {
+    nativeAppService.close();
   }
 }

--- a/src/background/actions/TokenSigning/getStatus.ts
+++ b/src/background/actions/TokenSigning/getStatus.ts
@@ -31,10 +31,10 @@ import errorToResponse from "./errorToResponse";
 export default async function getStatus(
   nonce: string,
 ): Promise<TokenSigningStatusResponse | TokenSigningErrorResponse> {
+  const nativeAppService = new NativeAppService();
 
   try {
-    const nativeAppService = new NativeAppService();
-    const nativeAppStatus  = await nativeAppService.connect();
+    const nativeAppStatus = await nativeAppService.connect();
 
     // The token-signing uses x.y.z.build version string pattern
     const version = nativeAppStatus.version.replace("+", ".");
@@ -43,9 +43,16 @@ export default async function getStatus(
       throw new Error("missing native application version");
     }
 
+    await nativeAppService.send({
+      command:   "quit",
+      arguments: {},
+    });
+
     return tokenSigningResponse<TokenSigningStatusResponse>("ok", nonce, { version });
   } catch (error) {
     console.error(error);
     return errorToResponse(nonce, error);
+  } finally {
+    nativeAppService.close();
   }
 }

--- a/src/background/actions/TokenSigning/sign.ts
+++ b/src/background/actions/TokenSigning/sign.ts
@@ -41,9 +41,10 @@ export default async function sign(
   algorithm: string,
   lang?: string,
 ): Promise<TokenSigningSignResponse | TokenSigningErrorResponse> {
+  const nativeAppService = new NativeAppService();
+
   try {
-    const nativeAppService = new NativeAppService();
-    const nativeAppStatus  = await nativeAppService.connect();
+    const nativeAppStatus = await nativeAppService.connect();
 
     console.log("Sign: connected to native", nativeAppStatus);
 
@@ -74,5 +75,7 @@ export default async function sign(
   } catch (error) {
     console.error(error);
     return errorToResponse(nonce, error);
+  } finally {
+    nativeAppService.close();
   }
 }

--- a/src/background/actions/authenticate.ts
+++ b/src/background/actions/authenticate.ts
@@ -145,6 +145,6 @@ export default async function authenticate(
       error:  serializeError(error),
     };
   } finally {
-    if (nativeAppService) nativeAppService.close();
+    nativeAppService?.close();
   }
 }

--- a/src/background/actions/getStatus.ts
+++ b/src/background/actions/getStatus.ts
@@ -28,10 +28,11 @@ import NativeAppService from "../services/NativeAppService";
 
 export default async function getStatus(): Promise<any> {
   const extension = config.VERSION;
+  const nativeAppService = new NativeAppService();
 
   try {
-    const nativeAppService = new NativeAppService();
-    const status           = await nativeAppService.connect();
+
+    const status = await nativeAppService.connect();
 
     const nativeApp = (
       status.version.startsWith("v")
@@ -39,7 +40,10 @@ export default async function getStatus(): Promise<any> {
         : status.version
     );
 
-    nativeAppService.close();
+    await nativeAppService.send({
+      command:   "quit",
+      arguments: {},
+    });
 
     return {
       extension,
@@ -56,5 +60,7 @@ export default async function getStatus(): Promise<any> {
       action: Action.STATUS_FAILURE,
       error:  serializeError(error),
     };
+  } finally {
+    nativeAppService.close();
   }
 }

--- a/src/background/actions/sign.ts
+++ b/src/background/actions/sign.ts
@@ -27,7 +27,7 @@ import ServerTimeoutError from "@web-eid/web-eid-library/errors/ServerTimeoutErr
 import OriginMismatchError from "@web-eid/web-eid-library/errors/OriginMismatchError";
 import { serializeError } from "@web-eid/web-eid-library/utils/errorSerializer";
 
-import NativeAppService, { NativeAppState } from "../services/NativeAppService";
+import NativeAppService from "../services/NativeAppService";
 import WebServerService from "../services/WebServerService";
 import HttpResponse from "../../models/HttpResponse";
 import TypedMap from "../../models/TypedMap";
@@ -119,15 +119,8 @@ export default async function sign(
 
     console.log("Sign: postPrepareSigningUrl fetched", prepareDocumentResult);
 
-    console.log("Native app state", nativeAppService.state);
-
-    if (nativeAppService.state === NativeAppState.CONNECTED) {
-      nativeAppService.close();
-    }
-
     nativeAppService = new NativeAppService();
-
-    nativeAppStatus = await nativeAppService.connect();
+    nativeAppStatus  = await nativeAppService.connect();
 
     console.log("Sign: reconnected to native", nativeAppStatus);
 
@@ -204,6 +197,6 @@ export default async function sign(
       error:  serializeError(error),
     };
   } finally {
-    if (nativeAppService) nativeAppService.close();
+    nativeAppService?.close();
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,12 @@ export default Object.freeze({
 
   NATIVE_MESSAGE_MAX_BYTES: 8192,
 
+  /**
+   * Time given in milliseconds to native application for closing gracefully after a command reply.
+   * On timeout, the native application communication port is forcefully disconnected.
+   */
+  NATIVE_GRACEFUL_DISCONNECT_TIMEOUT: 2000, // 2 seconds
+
   TOKEN_SIGNING_BACKWARDS_COMPATIBILITY:  true,
   TOKEN_SIGNING_USER_INTERACTION_TIMEOUT: 1000 * 60 * 5, // 5 minutes
 });

--- a/src/models/NativeAppMessage.ts
+++ b/src/models/NativeAppMessage.ts
@@ -1,0 +1,41 @@
+export interface NativeAppCommandGetCertificate {
+  command: "get-certificate";
+  arguments: {
+    "type": "auth" | "sign";
+    "origin": string;
+    "lang"?: string;
+  };
+}
+
+export interface NativeAppCommandAuthenticate {
+  command: "authenticate";
+  arguments: {
+    "nonce": string;
+    "origin": string;
+    "origin-cert": string | null;
+    "lang"?: string;
+  };
+}
+
+export interface NativeAppCommandSign {
+  command: "sign";
+  arguments: {
+    "doc-hash": string;
+    "hash-algo": string;
+    "user-eid-cert": string;
+    "origin": string;
+    "lang"?: string;
+  };
+}
+
+export interface NativeAppCommandQuit {
+  command: "quit";
+  arguments: {};
+}
+
+
+export type NativeAppMessage
+  = NativeAppCommandGetCertificate
+  | NativeAppCommandAuthenticate
+  | NativeAppCommandSign
+  | NativeAppCommandQuit;


### PR DESCRIPTION
Works together with web-eid/web-eid-app#82

Changes:
* For native application status checking, use the new "quit" command to gracefully terminate the native application
* For all browsers, except Safari, when sending a command to native app, wait up to 2 seconds for the native app to terminate before forcefully closing the communication port
* Minor type safety improvements
* NPM security audit auto-fix for the build dependency **lodash**