### PR TITLE
fix: deprecated OpenSSL digest commands should be allowed for backwards compatibility

### DIFF
--- a/src/background/actions/TokenSigning/digestCommands.ts
+++ b/src/background/actions/TokenSigning/digestCommands.ts
@@ -1,0 +1,19 @@
+import TypedMap from "../../../models/TypedMap";
+
+/**
+ * Map of OpenSSL digest commands to digest algorithm names.
+ *
+ * OpenSSL digest commands are deprecated. This is only provided for backwards compatibility.
+ *
+ * @see https://www.openssl.org/docs/manmaster/man1/openssl-list.html
+ */
+export default {
+  "sha224":   "SHA-224",
+  "sha256":   "SHA-256",
+  "sha384":   "SHA-384",
+  "sha512":   "SHA-512",
+  "sha3-224": "SHA3-224",
+  "sha3-256": "SHA3-256",
+  "sha3-384": "SHA3-384",
+  "sha3-512": "SHA3-512",
+} as TypedMap<string>;

--- a/src/background/actions/TokenSigning/sign.ts
+++ b/src/background/actions/TokenSigning/sign.ts
@@ -32,6 +32,7 @@ import {
 } from "../../../models/TokenSigning/TokenSigningResponse";
 import { throwAfterTimeout } from "../../../shared/utils";
 import errorToResponse from "./errorToResponse";
+import digestCommands from "./digestCommands";
 
 export default async function sign(
   nonce: string,
@@ -54,7 +55,7 @@ export default async function sign(
 
         arguments: {
           "doc-hash":      new ByteArray().fromHex(hash).toBase64(),
-          "hash-algo":     algorithm,
+          "hash-algo":     Object.keys(digestCommands).includes(algorithm) ? digestCommands[algorithm] : algorithm,
           "origin":        (new URL(sourceUrl)).origin,
           "user-eid-cert": new ByteArray().fromHex(certificate).toBase64(),
 


### PR DESCRIPTION
Resolves: WE2-447