### PR TITLE
feat: language option support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ __pycache__
 
 # Vim
 *.swp
+
+# Visual Studio Code
+.vscode/

--- a/src/background/actions/TokenSigning/getCertificate.ts
+++ b/src/background/actions/TokenSigning/getCertificate.ts
@@ -32,6 +32,7 @@ import {
 } from "../../../models/TokenSigning/TokenSigningResponse";
 import { throwAfterTimeout } from "../../../shared/utils";
 import errorToResponse from "./errorToResponse";
+import threeLetterLanguageCodes from "./threeLetterLanguageCodes";
 
 export default async function getCertificate(
   nonce: string,
@@ -39,6 +40,10 @@ export default async function getCertificate(
   lang?: string,
   filter: "AUTH" | "SIGN" = "SIGN",
 ): Promise<TokenSigningCertResponse | TokenSigningErrorResponse> {
+  if (lang && Object.keys(threeLetterLanguageCodes).includes(lang)) {
+    lang = threeLetterLanguageCodes[lang];
+  }
+
   const nativeAppService = new NativeAppService();
 
   if (filter !== "SIGN") {
@@ -63,8 +68,7 @@ export default async function getCertificate(
         arguments: {
           "origin": (new URL(sourceUrl)).origin,
 
-          // TODO: Implement i18n in native application
-          // "lang": lang
+          ...(lang ? { lang } : {}),
         },
       }),
 

--- a/src/background/actions/TokenSigning/sign.ts
+++ b/src/background/actions/TokenSigning/sign.ts
@@ -33,6 +33,7 @@ import {
 import { throwAfterTimeout } from "../../../shared/utils";
 import errorToResponse from "./errorToResponse";
 import digestCommands from "./digestCommands";
+import threeLetterLanguageCodes from "./threeLetterLanguageCodes";
 
 export default async function sign(
   nonce: string,
@@ -42,6 +43,10 @@ export default async function sign(
   algorithm: string,
   lang?: string,
 ): Promise<TokenSigningSignResponse | TokenSigningErrorResponse> {
+  if (lang && Object.keys(threeLetterLanguageCodes).includes(lang)) {
+    lang = threeLetterLanguageCodes[lang];
+  }
+
   const nativeAppService = new NativeAppService();
 
   try {
@@ -59,8 +64,7 @@ export default async function sign(
           "origin":        (new URL(sourceUrl)).origin,
           "user-eid-cert": new ByteArray().fromHex(certificate).toBase64(),
 
-          // TODO: Implement i18n in native application
-          // "lang": lang
+          ...(lang ? { lang } : {}),
         },
       }),
       throwAfterTimeout(config.TOKEN_SIGNING_USER_INTERACTION_TIMEOUT, new UserTimeoutError()),

--- a/src/background/actions/TokenSigning/threeLetterLanguageCodes.ts
+++ b/src/background/actions/TokenSigning/threeLetterLanguageCodes.ts
@@ -1,0 +1,17 @@
+import TypedMap from "../../../models/TypedMap";
+
+/**
+ * Map of ISO 639-2 three-letter language codes to ISO 639-1 two-letter language codes.
+ *
+ * This is only a partial list used for backwards compatibility.
+ *
+ * @see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+ */
+export default {
+  "est": "et",
+  "eng": "en",
+  "rus": "ru",
+  "lit": "lt",
+  "lat": "lv",
+  "tur": "tr",
+} as TypedMap<string>;

--- a/src/background/actions/authenticate.ts
+++ b/src/background/actions/authenticate.ts
@@ -40,6 +40,7 @@ export default async function authenticate(
   headers: TypedMap<string>,
   userInteractionTimeout: number,
   serverRequestTimeout: number,
+  lang?: string,
 ): Promise<object | void> {
   let webServerService: WebServerService | undefined;
   let nativeAppService: NativeAppService | undefined;
@@ -93,6 +94,8 @@ export default async function authenticate(
               ? new ByteArray(response.certificateInfo?.rawDER).toBase64()
               : null
           ),
+
+          ...(lang ? { lang } : {}),
         },
       }),
 

--- a/src/background/actions/sign.ts
+++ b/src/background/actions/sign.ts
@@ -39,6 +39,7 @@ export default async function sign(
   headers: TypedMap<string>,
   userInteractionTimeout: number,
   serverRequestTimeout: number,
+  lang?: string,
 ): Promise<object | void> {
   let webServerService: WebServerService | undefined;
   let nativeAppService: NativeAppService | undefined;
@@ -69,6 +70,8 @@ export default async function sign(
 
         arguments: {
           "origin": (new URL(postPrepareSigningUrl)).origin,
+
+          ...(lang ? { lang } : {}),
         },
       }),
 
@@ -132,6 +135,8 @@ export default async function sign(
           "hash-algo":     prepareDocumentResult.body.algorithm,
           "origin":        (new URL(postPrepareSigningUrl)).origin,
           "user-eid-cert": certificate,
+
+          ...(lang ? { lang } : {}),
         },
       }),
 

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -41,6 +41,7 @@ async function onAction(message: LibraryMessage): Promise<void | object> {
         message.headers,
         message.userInteractionTimeout || libraryConfig.DEFAULT_USER_INTERACTION_TIMEOUT,
         message.serverRequestTimeout   || libraryConfig.DEFAULT_SERVER_REQUEST_TIMEOUT,
+        message.lang,
       );
 
     case Action.SIGN:
@@ -50,6 +51,7 @@ async function onAction(message: LibraryMessage): Promise<void | object> {
         message.headers,
         message.userInteractionTimeout || libraryConfig.DEFAULT_USER_INTERACTION_TIMEOUT,
         message.serverRequestTimeout   || libraryConfig.DEFAULT_SERVER_REQUEST_TIMEOUT,
+        message.lang,
       );
 
     case Action.STATUS:

--- a/src/models/LibraryMessage.ts
+++ b/src/models/LibraryMessage.ts
@@ -39,6 +39,7 @@ export interface AuthenticateRequestMessage extends Object {
   headers: TypedMap<string>;
   userInteractionTimeout: number;
   serverRequestTimeout: number;
+  lang?: string;
 }
 
 export interface SignRequestMessage extends Object {
@@ -48,4 +49,5 @@ export interface SignRequestMessage extends Object {
   headers: TypedMap<string>;
   userInteractionTimeout: number;
   serverRequestTimeout: number;
+  lang?: string;
 }


### PR DESCRIPTION
* For TokenSigning backwards compatibility, some three-letter language codes are supported when used through hwcrypto.js
* The extension does not set a default language - when language is not specified, the attribute is not included in the native application message