### PR TITLE
feat: passing the certificate to the native app should be behind a build-time feature switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ APIs, like the smart card subsystem.
     SOURCE_DATE_EPOCH=$(cat ../previous-build/dist/firefox/SOURCE_DATE_EPOCH) npm run clean build package
     ```
 
+    For the **experimental** origin certificate validation feature, which uses the webRequest API and is only available in Firefox, set the `ORIGIN_CERTIFICATE_VALIDATION` environment variable to `true`.
+    ```bash
+    ORIGIN_CERTIFICATE_VALIDATION=true npm run clean build package
+    ```
+
 5. Load in Firefox as a Temporary Extension
     1. Open [about:debugging#/runtime/this-firefox](about:debugging#/runtime/this-firefox)
     2. Click "Load temporary Add-on..." and open `/web-eid-webextension/dist/manifest.json`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "web-eid-webextension",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-eid-webextension",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/scripts/build-utils.mjs
+++ b/scripts/build-utils.mjs
@@ -132,8 +132,24 @@ export async function getSourceDateEpoch() {
   };
 }
 
+export function isOriginCertificateValidationEnabled() {
+  return (
+    process.env.ORIGIN_CERTIFICATE_VALIDATION
+      ? process.env.ORIGIN_CERTIFICATE_VALIDATION.toUpperCase() == "TRUE"
+      : false
+  )
+}
+
 export async function write(filename, data) {
   console.log(`WRITE ${data} → ${filename}`);
 
   await fs.writeFile(filename, data);
+}
+
+export async function updateJson(filename, updateFn) {
+  console.log(`UPDATE ${filename} with ${updateFn}`);
+
+  const json = await fs.readJson(filename);
+
+  await fs.writeJson(filename, updateFn(json), { spaces: 2 });
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,4 +1,16 @@
-import { cp, rm, exec, zip, replace, rem, pkg, write, getSourceDateEpoch } from "./build-utils.mjs";
+import {
+  cp,
+  rm,
+  exec,
+  zip,
+  replace,
+  rem,
+  pkg,
+  write,
+  updateJson,
+  getSourceDateEpoch,
+  isOriginCertificateValidationEnabled,
+} from "./build-utils.mjs";
 
 let sourceDateEpoch;
 
@@ -72,6 +84,13 @@ const targets = {
     );
     await cp("./static/firefox/manifest.json", "./dist/firefox/manifest.json");
     await replace("./dist/firefox/manifest.json", "{{package.version}}", pkg.version);
+
+    if (isOriginCertificateValidationEnabled()) {
+      updateJson(
+        "./dist/firefox/manifest.json",
+        (manifest) => ({...manifest, permissions: [...manifest.permissions, "webRequest", "webRequestBlocking"]})
+      )
+    }
 
     rem(
       "Setting up the Chrome manifest"

--- a/src/background/services/WebServerService.ts
+++ b/src/background/services/WebServerService.ts
@@ -55,8 +55,12 @@ export default class WebServerService {
           "webRequestBlocking",
         ],
       });
+
+      if (hasWebRequestPermission) {
+        console.log("Got permissions for webRequest API");
+      }
     } catch(error) {
-      console.log("Failed to fetch permissions", error);
+      console.log("Failed to fetch webRequest permissions", error);
     }
 
     certificateInfo = null;
@@ -66,6 +70,8 @@ export default class WebServerService {
         details.requestId,
         { rawDER: true }
       );
+
+      console.log("Inspecting webRequest securityInfo");
 
       switch (securityInfo.state) {
         case "secure": {
@@ -77,6 +83,8 @@ export default class WebServerService {
             fetchError = new CertificateChangedError();
             return { cancel: true };
           }
+
+          console.log("TLS state is secure");
 
           break;
         }

--- a/static/firefox/manifest.json
+++ b/static/firefox/manifest.json
@@ -31,8 +31,6 @@
   },
   "permissions": [
     "*://*/*",
-    "webRequest",
-    "webRequestBlocking",
     "nativeMessaging"
   ]
 }


### PR DESCRIPTION
* WebRequest handling is now disabled by default in Firefox, it was already disabled in other browsers
* WebRequest handling in Firefox can be enabled via ORIGIN_CERTIFICATE_VALIDATION environment variable
* Updated README.md
* Version bump to 1.1.0