### PR TITLE
fix: Error while inject TokenSigning page script when using manifest v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-eid-webextension",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "web-eid-webextension",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^3.1.8",
@@ -4365,9 +4365,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -4900,20 +4900,20 @@
       }
     },
     "node_modules/rollup-plugin-license": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-2.7.0.tgz",
-      "integrity": "sha512-0H1Fbuf85rvpadpmAaairdahzQHY0zHtcXkOFV5EStjX9aMCO2Hz5AQp/zZe+K/PB3o6As7R9uzcb8Pw1K94dg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-2.8.2.tgz",
+      "integrity": "sha512-jv268aj71J0Ee6+isjy1mYD2LlwuNg6aUiSdgly0PS0fQ2+vsuc+PLx1ueSk2/QKfjk5OJzcGPEDMHyoIeAFCw==",
       "dev": true,
       "dependencies": {
-        "commenting": "1.1.0",
-        "glob": "7.2.0",
-        "lodash": "4.17.21",
-        "magic-string": "0.26.1",
-        "mkdirp": "1.0.4",
-        "moment": "2.29.2",
-        "package-name-regex": "2.0.6",
-        "spdx-expression-validate": "2.0.0",
-        "spdx-satisfies": "5.0.1"
+        "commenting": "~1.1.0",
+        "glob": "~7.2.0",
+        "lodash": "~4.17.21",
+        "magic-string": "~0.26.2",
+        "mkdirp": "~1.0.4",
+        "moment": "~2.29.3",
+        "package-name-regex": "~2.0.6",
+        "spdx-expression-validate": "~2.0.0",
+        "spdx-satisfies": "~5.0.1"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -4923,9 +4923,9 @@
       }
     },
     "node_modules/rollup-plugin-license/node_modules/magic-string": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.1.tgz",
-      "integrity": "sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==",
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
       "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
@@ -9133,9 +9133,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true
     },
     "ms": {
@@ -9516,26 +9516,26 @@
       }
     },
     "rollup-plugin-license": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-2.7.0.tgz",
-      "integrity": "sha512-0H1Fbuf85rvpadpmAaairdahzQHY0zHtcXkOFV5EStjX9aMCO2Hz5AQp/zZe+K/PB3o6As7R9uzcb8Pw1K94dg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-2.8.2.tgz",
+      "integrity": "sha512-jv268aj71J0Ee6+isjy1mYD2LlwuNg6aUiSdgly0PS0fQ2+vsuc+PLx1ueSk2/QKfjk5OJzcGPEDMHyoIeAFCw==",
       "dev": true,
       "requires": {
-        "commenting": "1.1.0",
-        "glob": "7.2.0",
-        "lodash": "4.17.21",
-        "magic-string": "0.26.1",
-        "mkdirp": "1.0.4",
-        "moment": "2.29.2",
-        "package-name-regex": "2.0.6",
-        "spdx-expression-validate": "2.0.0",
-        "spdx-satisfies": "5.0.1"
+        "commenting": "~1.1.0",
+        "glob": "~7.2.0",
+        "lodash": "~4.17.21",
+        "magic-string": "~0.26.2",
+        "mkdirp": "~1.0.4",
+        "moment": "~2.29.3",
+        "package-name-regex": "~2.0.6",
+        "spdx-expression-validate": "~2.0.0",
+        "spdx-satisfies": "~5.0.1"
       },
       "dependencies": {
         "magic-string": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.1.tgz",
-          "integrity": "sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==",
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+          "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
           "dev": true,
           "requires": {
             "sourcemap-codec": "^1.4.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-eid-webextension",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -82,4 +82,33 @@ export default [
 
     context: "window",
   })),
+
+  {
+    input: "./dist/firefox/resources/token-signing-page-script.js",
+
+    output: [
+      {
+        file:      "dist/firefox/token-signing-page-script.js",
+        format:    "iife",
+        sourcemap: true,
+      },
+    ],
+
+    plugins: [
+      libraryAlias,
+      resolve({ rootDir: "./dist" }),
+      cleanup({ comments: ["jsdoc"] }),
+      license({
+        banner: {
+          content: {
+            // eslint-disable-next-line no-undef
+            file:     path.join(__dirname, "LICENSE"),
+            encoding: "utf-8",
+          },
+        },
+      }),
+    ],
+
+    context: "window",
+  },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default [
       {
         file:      `dist/firefox/${name}.js`,
         format:    "iife",
-        sourcemap: true,
+        sourcemap: name === "background",
       },
     ],
 
@@ -57,7 +57,7 @@ export default [
       {
         file:      `dist/safari/${name}.js`,
         format:    "iife",
-        sourcemap: true,
+        sourcemap: name === "background",
       },
     ],
 
@@ -88,9 +88,8 @@ export default [
 
     output: [
       {
-        file:      "dist/firefox/token-signing-page-script.js",
-        format:    "iife",
-        sourcemap: true,
+        file:   "dist/firefox/token-signing-page-script.js",
+        format: "iife",
       },
     ],
 

--- a/src/models/Browser/Runtime.ts
+++ b/src/models/Browser/Runtime.ts
@@ -94,6 +94,19 @@ export default interface Runtime {
   ) => Promise<object | void>;
 
   connectNative: (application: string) => Port;
+
+  /**
+   * Given a relative path from the manifest.json to a resource packaged with the extension,
+   * return a fully-qualified URL.
+   *
+   * This function does not check that the resource actually exists at that URL.
+   */
+  getURL: (path: string) => string;
+
+  /**
+   * Get the complete manifest.json file, deserialized from JSON to an object.
+   */
+  getManifest: () => any;
 }
 
 export interface Port {

--- a/src/resources/token-signing-page-script.ts
+++ b/src/resources/token-signing-page-script.ts
@@ -20,33 +20,8 @@
  * SOFTWARE.
  */
 
-import pageScript from "../../shared/TokenSigningPageScript";
+import pageScript from "../shared/TokenSigningPageScript";
+import patchHwcrypto from "../shared/HwcryptoPatcher";
 
-export default function injectPageScript(): void {
-  /**
- * Check the page for an existing TokenSigning page script.
- * The script will be injected to the DOM of every page, which doesn't already have the script.
- * To circumvent Content Security Policy issues, the website can include the script on its own.
- *
- * Example:
- *   <script src="path-to/page.js" data-name="TokenSigning"></script>
- *
- * The page script can be found here:
- *   https://github.com/open-eid/chrome-token-signing/blob/master/extension/page.js
- */
-  if (!document.querySelector("script[data-name='TokenSigning']")) {
-    const s = document.createElement("script");
-
-    s.type = "text/javascript";
-    s.dataset.name = "TokenSigning";
-    s.dataset.by = "Web-eID extension";
-
-    if (browser.runtime.getManifest()["manifest_version"] !== 2) {
-      s.src = browser.runtime.getURL("token-signing-page-script.js");
-    } else {
-      s.innerHTML = "(" + pageScript + ")();";
-    }
-
-    (document.head || document.documentElement).appendChild(s);
-  }
-}
+pageScript();
+patchHwcrypto();

--- a/src/shared/HwcryptoPatcher.ts
+++ b/src/shared/HwcryptoPatcher.ts
@@ -1,0 +1,46 @@
+interface Hwcrypto {
+  [key: string]: any;
+
+  use: (backend?: "chrome") => Promise<any>;
+  sign: (cert: string, hash: string, options: any) => Promise<any>;
+  debug: () => Promise<any>;
+  getCertificate: (options: any) => Promise<any>;
+}
+
+let isPatched = false;
+let isRetried = false;
+
+const patchHwcryptoFunction = (hwc: Hwcrypto) => (fnName: string) => {
+  const originalFn = hwc[fnName];
+
+  hwc[fnName] = async function(...args: any[]): Promise<any> {
+    try {
+      return await originalFn.apply(this, args);
+    } catch (error) {
+      const isNoImpl = (error as Error)?.message === "no_implementation";
+
+      if (isNoImpl && !isRetried) {
+        isRetried = true;
+
+        // Force hwcrypto to re-detect the extension
+        await hwc.use("chrome");
+
+        // Try the Hwcrypto function again
+        return await originalFn.apply(this, args);
+      } else {
+        // re-throw the original error
+        throw error;
+      }
+    }
+  };
+};
+
+export default function patchHwcrypto(): void {
+  const hwc = (globalThis as any)?.hwcrypto;
+
+  if (!hwc || isPatched) return;
+
+  ["debug", "sign", "getCertificate"].forEach(patchHwcryptoFunction(hwc));
+
+  isPatched = true;
+}

--- a/src/shared/TokenSigningPageScript.ts
+++ b/src/shared/TokenSigningPageScript.ts
@@ -23,15 +23,15 @@
 import {
   TokenSigningCertResponse,
   TokenSigningResponse,
-} from "../../models/TokenSigning/TokenSigningResponse";
+} from "../models/TokenSigning/TokenSigningResponse";
 import {
   TokenSigningGetCertificateMessage,
   TokenSigningMessage,
   TokenSigningSignMessage,
   TokenSigningVersionMessage,
-} from "../../models/TokenSigning/TokenSigningMessage";
+} from "../models/TokenSigning/TokenSigningMessage";
 
-import TokenSigningPromise from "../../models/TokenSigning/TokenSigningPromise";
+import TokenSigningPromise from "../models/TokenSigning/TokenSigningPromise";
 
 declare global {
   interface Window {

--- a/static/chrome/manifest.json
+++ b/static/chrome/manifest.json
@@ -6,6 +6,10 @@
   "icons": {
     "128": "icons/web-eid-icon-128.png"
   },
+  "web_accessible_resources": [{
+    "resources": ["token-signing-page-script.js"],
+    "matches": ["<all_urls>"]
+  }],
   "content_scripts": [
     {
       "js": [

--- a/static/firefox/manifest_v3.json
+++ b/static/firefox/manifest_v3.json
@@ -11,6 +11,10 @@
   "icons": {
     "128": "icons/web-eid-icon-128.png"
   },
+  "web_accessible_resources": [{
+    "resources": ["token-signing-page-script.js"],
+    "matches": ["<all_urls>"]
+  }],
   "content_scripts": [
     {
       "js": [

--- a/static/safari/manifest_v3.json
+++ b/static/safari/manifest_v3.json
@@ -7,6 +7,10 @@
   "icons": {
     "128": "web-eid-icon-128.png"
   },
+  "web_accessible_resources": [{
+    "resources": ["token-signing-page-script.js"],
+    "matches": ["<all_urls>"]
+  }],
   "content_scripts": [
     {
       "js": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "declaration": true,
     "declarationMap": true,
     "moduleResolution": "node",
-    "sourceMap": true,
     "strict": true,
     "outDir": "dist",
     "baseUrl": ".",


### PR DESCRIPTION
With manifest v3, it's not allowed to inject dynamic scripts to a web page. Instead the script needs to be exposed as an extension resource and then loaded via a resource URL.  

From my experiments loading the TokenSigning page script takes more time to initialize when loaded form extension resources.  
If the website itself tries to use Hwcrypto before the TokenSigning script has initialized, for example the `hwcrypto.use()` function during page load, it may leads to a situation where Hwcrypto will throw "no_implementation" and will not allow you to attempt `hwcrypto.sign(...)` or `hwcrypto.getCertificate(...)`.  
Although this issue should be rare, I tried to fix this situation by patching hwcrypto's "debug", "sign" and "getCertificate" functions so if they fail with "no_implementation" they would call `hwcrypto.use("chrome")` to detect the extension again and then retry the debug/sign/getCertificate operation.

Without patching the hwcrypto functions, websites would need to match all of the following criteria to run into this issue:
- They rely on the injecting mechanism instead of hosting the TokenSigning script themselves
  - Those websites wouldn't have a strict Content-Security-Policy setup to script injection, which isn't recommended anyway.
- Websites that call hwcrypto methods during page load, instead of only calling the methods in a user-interaction event like a button click.