### PR TITLE
Fixes rollup issues - Build failing with Node v20 and Microsoft PowerApps editor hanging

### DIFF
--- a/scripts/build-utils.mjs
+++ b/scripts/build-utils.mjs
@@ -43,10 +43,10 @@ export function exec(command, args = []) {
   }
 
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args);
-
-    child.stdout.pipe(process.stdout);
-    child.stderr.pipe(process.stderr);
+    const child = spawn(command, args, {
+      cwd: '.',
+      stdio: 'inherit'
+    });
 
     child.on("close", (code) => {
       if (code == 0) {


### PR DESCRIPTION
## Fix: Build failing with Node v20
Bundling with Rollup failed with exit code `1`.  
Piping stdout and stderr, ignoring stdin, while executing Rollup doesn't seem to behave as expected.  
Changed from piping to `stdio: 'inherit'` to fix the issue. This is an old option and should be more stable in any Node version.

## Fix: Microsoft PowerApps editor hangs on loading screen
Rollup plugin `injectProcessEnv` was used while compiling `token-signing-page-script.js`.  
That script is injected to the page when TokenSigning backwards compatibility is turned on.  
It then included code which made the PowerApps editor think it's code was running in Node.js (more specifically in Linux or Mac) instead of the browser, and then crashed.  
After the change, `injectProcessEnv` plugin is only used while compiling the code which runs in the WebExtension context and doesn't interfere with the website's code.