### PR TITLE
Fix failing windows build after Node security update CVE-2024-27980

### DIFF
--- a/scripts/build-utils.mjs
+++ b/scripts/build-utils.mjs
@@ -47,7 +47,8 @@ export function exec(command, args = []) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd: '.',
-      stdio: 'inherit'
+      stdio: 'inherit',
+      ...isWindows && { shell: true },
     });
 
     child.on("close", (code) => {


### PR DESCRIPTION
- CVE-2024-27980
- https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
- This security issue is not relevant for a build tool