### PR TITLE
Log TOKEN_SIGNING_BACKWARDS_COMPATIBILITY env variable during builds

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -79,6 +79,10 @@ const targets = {
   },
 
   async build() {
+    rem(
+      "Environment variables affecting the build:",
+      `TOKEN_SIGNING_BACKWARDS_COMPATIBILITY=${process.env.TOKEN_SIGNING_BACKWARDS_COMPATIBILITY?.toUpperCase() === "TRUE"} (hwcrypto support enabled)`
+    );
     await this.compile();
 
     await this.bundle();

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -37,7 +37,7 @@ const targets = {
   },
 
   async bundle() {
-    if (pkg.version == manifestVersion) {
+    if (pkg.version === manifestVersion) {
       rem(
         `Build version: ${pkg.version}`
       );


### PR DESCRIPTION
WE2-1177

- **build: Log TOKEN_SIGNING_BACKWARDS_COMPATIBILITY env variable to build logs**
- **build: fix warning Comparison pkg.version == manifestVersion may cause unexpected type coercion**
