### PR TITLE
DevTools tab for debugging

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2024 Estonian Information System Authority
+Copyright (c) Estonian Information System Authority
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -48,11 +48,6 @@ The Web eID extension for Safari is built as a [Safari web extension](https://de
     TOKEN_SIGNING_BACKWARDS_COMPATIBILITY=true npm run clean build package
     ```
 
-    During development, for additional logging, set the `DEBUG` environment variable to `true`.
-    ```bash
-    DEBUG=true npm run clean build package
-    ```
-
 5. Load in Firefox as a Temporary Extension
     1. Open `about:debugging#/runtime/this-firefox`
     2. Click "Load temporary Add-on..." and open `/web-eid-webextension/dist/manifest.json`
@@ -62,3 +57,33 @@ The Web eID extension for Safari is built as a [Safari web extension](https://de
 Make sure the `NATIVE_APP_NAME` value in `src/config.ts` matches the one in
 the Web-eID native application manifest file.
 
+### Developer tools
+
+The Web eID DevTools tab can be useful while integrating Web eID on a website.
+
+#### Features
+- Event history between the website, extension and native application.
+- Extension's internal log messages.
+- Option to override extension settings, without needing to compile the extension yourself.
+- Option to allow the http://localhost origin when authenticating and signing
+
+#### Enable or disable the Web eID developer tools tab
+
+**Firefox**
+1. Open [Menu -> Settings -> Extensions and themes]  
+   or navigate to the address `about:addons`
+2. Open the Web eID extension details
+3. Open the "Permissions" tab
+4. Toggle "Extend developer tools to access your data in open tabs"
+
+**Chrome**
+1. Open [Settings -> Extensions]  
+   or navigate to the address `chrome://extensions/`
+2. Open the Web eID extension details
+3. Open "Extension options"
+4. Toggle "Enable developer tools"
+
+**Safari**
+1. Open [Settings -> Extensions]
+2. Open the Web eID Settings
+3. Toggle "Enable developer tools"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,13 +11,10 @@ import license from "rollup-plugin-license";
 import polyfill from "rollup-plugin-polyfill";
 import resolve from "@rollup/plugin-node-resolve";
 
-const projectRootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
-
 // List of browsers to build for.
 const browsers = ["chrome", "firefox", "safari"];
 
 const processEnvConf = {
-  DEBUG:                                 process.env.DEBUG,
   TOKEN_SIGNING_BACKWARDS_COMPATIBILITY: process.env.TOKEN_SIGNING_BACKWARDS_COMPATIBILITY,
 }
 
@@ -25,7 +22,7 @@ const pluginsConf = (environment) => [
   alias({
     entries: [{
       find:        "@web-eid.js",
-      replacement: path.resolve(projectRootDir, "dist/lib/web-eid.js/src"),
+      replacement: path.resolve(import.meta.dirname, "dist/lib/web-eid.js/src"),
     }],
   }),
   resolve({ rootDir: "./dist" }),
@@ -33,7 +30,7 @@ const pluginsConf = (environment) => [
   license({
     banner: {
       content: {
-        file:     path.join(projectRootDir, "LICENSE"),
+        file:     path.join(import.meta.dirname, "LICENSE"),
         encoding: "utf-8",
       },
     },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -117,6 +117,25 @@ const targets = {
     await cp("./static/icons", "./dist/safari");
 
     rem(
+      "Copying static pages to Firefox dist directory"
+    );
+    await cp("./static/views", "./dist/firefox/views");
+    await rm("./dist/firefox/views/options.*");
+    await cp("./node_modules/webextension-polyfill/dist/browser-polyfill.min.js", "./dist/firefox/views/browser-polyfill.min.js");
+
+    rem(
+      "Copying static pages to Chrome dist directory"
+    );
+    await cp("./static/views", "./dist/chrome/views");
+    await cp("./node_modules/webextension-polyfill/dist/browser-polyfill.min.js", "./dist/chrome/views/browser-polyfill.min.js");
+
+    rem(
+      "Copying static pages to Safari dist directory"
+    );
+    await cp("./static/views", "./dist/safari/views");
+    await cp("./node_modules/webextension-polyfill/dist/browser-polyfill.min.js", "./dist/safari/views/browser-polyfill.min.js");
+
+    rem(
       "Setting up the Firefox manifest"
     );
     await cp("./static/firefox/manifest.json", "./dist/firefox/manifest.json");

--- a/src/background-safari/services/NativeAppService.ts
+++ b/src/background-safari/services/NativeAppService.ts
@@ -8,7 +8,11 @@ import libraryConfig from "@web-eid.js/config";
 
 import Mutex from "../../shared/Mutex";
 import calculateJsonSize from "../../shared/utils/calculateJsonSize";
-import config from "../../config";
+import { config } from "../../shared/configManager";
+
+import Logger from "../../shared/Logger";
+
+const logger = new Logger("NativeAppService.ts");
 
 type NativeAppPendingRequest =
   | { resolve?: (value: PromiseLike<any>) => void; reject?: (reason?: any) => void }
@@ -28,7 +32,13 @@ export default class NativeAppService {
 
   private pending: NativeAppPendingRequest = null;
 
+  constructor(tabId?: number) {
+    logger.tabId = tabId;
+  }
+
   async connect(): Promise<{ version: string }> {
+    logger.log("Connecting to the native application " + config.NATIVE_APP_NAME);
+
     this.state = NativeAppState.CONNECTING;
 
     try {
@@ -52,6 +62,8 @@ export default class NativeAppService {
       if (message.version) {
         this.state = NativeAppState.CONNECTED;
 
+        logger.info("Connected to the native application", message);
+
         return message;
       }
 
@@ -72,7 +84,8 @@ export default class NativeAppService {
   }
 
   close(error?: any): void {
-    config.DEBUG && console.log("Disconnecting from native app");
+    logger.info("Closing connection to native application");
+
     this.state = NativeAppState.DISCONNECTED;
 
     this.pending?.reject?.(error);
@@ -92,6 +105,8 @@ export default class NativeAppService {
           setTimeout(() => { reject(throwAfterTimeout); }, timeout );
 
           const onResponse = (message: any): void => {
+            logger.log("Response from native application", message);
+
             this.pending = null;
 
             if (message.error) {
@@ -101,13 +116,14 @@ export default class NativeAppService {
             }
           };
 
-          config.DEBUG && console.log("Sending message to native app", JSON.stringify(message));
-
           const messageSize = calculateJsonSize(message);
+
+          logger.info("Calculated message size", messageSize);
 
           if (messageSize > config.NATIVE_MESSAGE_MAX_BYTES) {
             throw new Error(`native application message exceeded ${config.NATIVE_MESSAGE_MAX_BYTES} bytes`);
           }
+          logger.log("Sending message to native application", message);
 
           browser.runtime.sendNativeMessage("application.id", message, onResponse);
         });

--- a/src/background-safari/services/NativeAppService.ts
+++ b/src/background-safari/services/NativeAppService.ts
@@ -11,6 +11,7 @@ import calculateJsonSize from "../../shared/utils/calculateJsonSize";
 import { config } from "../../shared/configManager";
 
 import Logger from "../../shared/Logger";
+import isLoopbackAddress from "../../shared/utils/isLoopbackAddress";
 
 const logger = new Logger("NativeAppService.ts");
 
@@ -123,6 +124,18 @@ export default class NativeAppService {
           if (messageSize > config.NATIVE_MESSAGE_MAX_BYTES) {
             throw new Error(`native application message exceeded ${config.NATIVE_MESSAGE_MAX_BYTES} bytes`);
           }
+
+          if (config.ALLOW_HTTP_LOCALHOST && message.arguments?.origin) {
+            const url = new URL(message.arguments.origin);
+
+            if (url.protocol === "http:" && isLoopbackAddress(url.hostname)) {
+              url.protocol = "https:";
+
+              message.arguments.origin = url.origin;
+              logger.warn("Setting ALLOW_HTTP_LOCALHOST enabled, replaced origin with " + message.arguments.origin);
+            }
+          }
+
           logger.log("Sending message to native application", message);
 
           browser.runtime.sendNativeMessage("application.id", message, onResponse);

--- a/src/background/actions/TokenSigning/getCertificate.ts
+++ b/src/background/actions/TokenSigning/getCertificate.ts
@@ -11,26 +11,41 @@ import {
 } from "../../../models/TokenSigning/TokenSigningResponse";
 
 import ByteArray from "../../../shared/ByteArray";
+import { MessageSender } from "../../../models/Browser/Runtime";
 import NativeAppService from "../../services/NativeAppService";
-import config from "../../../config";
+import { config } from "../../../shared/configManager";
 import errorToResponse from "./errorToResponse";
 import threeLetterLanguageCodes from "./threeLetterLanguageCodes";
 import tokenSigningResponse from "../../../shared/tokenSigningResponse";
 
+import Logger from "../../../shared/Logger";
+
+const logger = new Logger("TokenSigning/getCertificate.ts");
+
 export default async function getCertificate(
+  sender: MessageSender,
   nonce: string,
   sourceUrl: string,
   lang?: string,
   filter: "AUTH" | "SIGN" = "SIGN",
 ): Promise<TokenSigningCertResponse | TokenSigningErrorResponse> {
+  logger.tabId = sender.tab?.id;
+
+  logger.log("Certificate requested");
+
   if (lang && Object.keys(threeLetterLanguageCodes).includes(lang)) {
     lang = threeLetterLanguageCodes[lang];
+    logger.log("Language code converted to three-letter code", lang);
   }
 
-  const nativeAppService = new NativeAppService();
+  const nativeAppService = new NativeAppService(sender.tab?.id);
+
+  logger.info("Checking 'filter', should be 'SIGN'");
 
   if (filter !== "SIGN") {
     const { message, name, stack } = new Error("Web-eID only allows signing with a signing certificate");
+
+    logger.error({ message, name, stack });
 
     return tokenSigningResponse<TokenSigningErrorResponse>("not_allowed", nonce, {
       message,
@@ -40,9 +55,7 @@ export default async function getCertificate(
   }
 
   try {
-    const nativeAppStatus = await nativeAppService.connect();
-
-    config.DEBUG && console.log("Get certificate: connected to native", nativeAppStatus);
+    await nativeAppService.connect();
 
     const message: NativeGetSigningCertificateRequest = {
       command: "get-signing-certificate",
@@ -61,14 +74,20 @@ export default async function getCertificate(
     );
 
     if (!response?.certificate) {
+      logger.info("Certificate request failed. Expected 'certificate' was not found in the response");
+
       return tokenSigningResponse<TokenSigningErrorResponse>("no_certificates", nonce);
     } else {
+      logger.info("Returning success response");
+
       return tokenSigningResponse<TokenSigningCertResponse>("ok", nonce, {
         cert: new ByteArray().fromBase64(response.certificate).toHex(),
       });
     }
   } catch (error) {
-    console.error(error);
+    logger.info("Certificate request failed");
+    logger.error(error);
+
     return errorToResponse(nonce, error);
   } finally {
     nativeAppService.close();

--- a/src/background/actions/TokenSigning/sign.ts
+++ b/src/background/actions/TokenSigning/sign.ts
@@ -11,11 +11,16 @@ import {
 } from "../../../models/TokenSigning/TokenSigningResponse";
 
 import ByteArray from "../../../shared/ByteArray";
+import { MessageSender } from "../../../models/Browser/Runtime";
 import NativeAppService from "../../services/NativeAppService";
-import config from "../../../config";
+import { config } from "../../../shared/configManager";
 import errorToResponse from "./errorToResponse";
 import threeLetterLanguageCodes from "./threeLetterLanguageCodes";
 import tokenSigningResponse from "../../../shared/tokenSigningResponse";
+
+import Logger from "../../../shared/Logger";
+
+const logger = new Logger("TokenSigning/sign.ts");
 
 
 const digestCommandToHashFunction = {
@@ -41,6 +46,7 @@ const hashFunctionToLength = {
 } as Record<string, number>;
 
 export default async function sign(
+  sender: MessageSender,
   nonce: string,
   sourceUrl: string,
   certificate: string,
@@ -48,17 +54,21 @@ export default async function sign(
   algorithm: string,
   lang?: string,
 ): Promise<TokenSigningSignResponse | TokenSigningErrorResponse> {
+  logger.tabId = sender.tab?.id;
+
+  logger.log("Signing requested");
+
   if (lang && Object.keys(threeLetterLanguageCodes).includes(lang)) {
     lang = threeLetterLanguageCodes[lang];
+    logger.info("Language code converted to three-letter code", lang);
   }
 
-  const nativeAppService = new NativeAppService();
+  const nativeAppService = new NativeAppService(sender.tab?.id);
 
   try {
     const warnings: Array<string> = [];
-    const nativeAppStatus = await nativeAppService.connect();
 
-    config.DEBUG && console.log("Sign: connected to native", nativeAppStatus);
+    await nativeAppService.connect();
 
     let hashFunction = (
       Object.keys(digestCommandToHashFunction).includes(algorithm)
@@ -66,11 +76,15 @@ export default async function sign(
         : algorithm
     );
 
+    logger.debug("Selected hashing function", hashFunction);
+
     const expectedHashByteLength = (
       Object.keys(hashFunctionToLength).includes(hashFunction)
         ? hashFunctionToLength[hashFunction]
         : undefined
     );
+
+    logger.debug("Hash byte length", expectedHashByteLength);
 
     const hashByteArray = new ByteArray().fromHex(hash);
 
@@ -94,6 +108,8 @@ export default async function sign(
       }
     }
 
+    warnings.forEach((message) => logger.warn(message));
+
     const message: NativeSignRequest = {
       command: "sign",
 
@@ -115,8 +131,10 @@ export default async function sign(
     );
 
     if (!response?.signature) {
+      logger.info("Signing failed. Expected 'signature' was not found in the response");
       return tokenSigningResponse<TokenSigningErrorResponse>("technical_error", nonce);
     } else {
+      logger.info("Returning success response");
       return tokenSigningResponse<TokenSigningSignResponse>("ok", nonce, {
         signature: new ByteArray().fromBase64(response.signature).toHex(),
 
@@ -124,7 +142,9 @@ export default async function sign(
       });
     }
   } catch (error) {
-    console.error(error);
+    logger.info("Signing failed");
+    logger.error(error);
+
     return errorToResponse(nonce, error);
   } finally {
     nativeAppService.close();

--- a/src/background/actions/TokenSigning/status.ts
+++ b/src/background/actions/TokenSigning/status.ts
@@ -8,16 +8,26 @@ import {
   TokenSigningStatusResponse,
 } from "../../../models/TokenSigning/TokenSigningResponse";
 
+import { MessageSender } from "../../../models/Browser/Runtime";
 import NativeAppService from "../../services/NativeAppService";
-import config from "../../../config";
+import { config } from "../../../shared/configManager";
 import errorToResponse from "./errorToResponse";
 import tokenSigningResponse from "../../../shared/tokenSigningResponse";
 
+import Logger from "../../../shared/Logger";
+
+const logger = new Logger("TokenSigning/status.ts");
+
 
 export default async function status(
+  sender: MessageSender,
   nonce: string,
 ): Promise<TokenSigningStatusResponse | TokenSigningErrorResponse> {
-  const nativeAppService = new NativeAppService();
+  logger.tabId = sender.tab?.id;
+
+  const nativeAppService = new NativeAppService(sender.tab?.id);
+
+  logger.log("Status requested");
 
   try {
     const nativeAppStatus = await nativeAppService.connect();
@@ -29,15 +39,21 @@ export default async function status(
       throw new Error("missing native application version");
     }
 
+    logger.info("Closing native app by sending the 'quit' command");
+
     await nativeAppService.send(
       { command: "quit", arguments: {} },
       config.NATIVE_GRACEFUL_DISCONNECT_TIMEOUT,
       new UnknownError("native application failed to close gracefully"),
     );
 
+    logger.info("Returning success response");
+
     return tokenSigningResponse<TokenSigningStatusResponse>("ok", nonce, { version });
   } catch (error) {
-    console.error(error);
+    logger.info("Status check failed");
+    logger.error(error);
+
     return errorToResponse(nonce, error);
   } finally {
     nativeAppService.close();

--- a/src/background/actions/authenticate.ts
+++ b/src/background/actions/authenticate.ts
@@ -1,18 +1,21 @@
 // SPDX-FileCopyrightText: Estonian Information System Authority
 // SPDX-License-Identifier: MIT
 
+import { ExtensionAuthenticateResponse, ExtensionFailureResponse } from "@web-eid.js/models/message/ExtensionResponse";
 import Action from "@web-eid.js/models/Action";
 import { NativeAuthenticateRequest } from "@web-eid.js/models/message/NativeRequest";
 import { NativeAuthenticateResponse } from "@web-eid.js/models/message/NativeResponse";
 import UserTimeoutError from "@web-eid.js/errors/UserTimeoutError";
 
-import { ExtensionAuthenticateResponse, ExtensionFailureResponse } from "@web-eid.js/models/message/ExtensionResponse";
 import { MessageSender } from "../../models/Browser/Runtime";
 import NativeAppService from "../services/NativeAppService";
 import UnknownError from "@web-eid.js/errors/UnknownError";
 import actionErrorHandler from "../../shared/actionErrorHandler";
-import config from "../../config";
 import { getSenderUrl } from "../../shared/utils/sender";
+
+import Logger from "../../shared/Logger";
+
+const logger = new Logger("authenticate.ts");
 
 export default async function authenticate(
   challengeNonce: string,
@@ -21,14 +24,16 @@ export default async function authenticate(
   userInteractionTimeout: number,
   lang?: string,
 ): Promise<ExtensionAuthenticateResponse | ExtensionFailureResponse> {
+  logger.tabId = sender.tab?.id;
+
+  logger.log("Authentication requested");
+
   let nativeAppService: NativeAppService | undefined;
   let nativeAppStatus: { version: string } | undefined;
 
   try {
-    nativeAppService = new NativeAppService();
+    nativeAppService = new NativeAppService(sender.tab?.id);
     nativeAppStatus  = await nativeAppService.connect();
-
-    config.DEBUG && console.log("Authenticate: connected to native", nativeAppStatus);
 
     const message: NativeAuthenticateRequest = {
       command: "authenticate",
@@ -48,8 +53,6 @@ export default async function authenticate(
       new UserTimeoutError(),
     );
 
-    config.DEBUG && console.log("Authenticate: authentication token received");
-
     const isResponseValid = (
       response?.unverifiedCertificate &&
       response?.algorithm             &&
@@ -59,12 +62,17 @@ export default async function authenticate(
     );
 
     if (isResponseValid) {
+      logger.info("Returning success response");
+
       return { action: Action.AUTHENTICATE_SUCCESS, ...response };
     } else {
+      logger.info("Authentication response is invalid");
+
       throw new UnknownError("unexpected response from native application");
     }
   } catch (error) {
-    console.error("Authenticate:", error);
+    logger.info("Authentication failed");
+    logger.error(error);
 
     return actionErrorHandler(Action.AUTHENTICATE_FAILURE, error, libraryVersion, nativeAppStatus?.version);
   } finally {

--- a/src/background/actions/getSigningCertificate.ts
+++ b/src/background/actions/getSigningCertificate.ts
@@ -15,8 +15,11 @@ import {
 import { MessageSender } from "../../models/Browser/Runtime";
 import NativeAppService from "../services/NativeAppService";
 import actionErrorHandler from "../../shared/actionErrorHandler";
-import config from "../../config";
 import { getSenderUrl } from "../../shared/utils/sender";
+
+import Logger from "../../shared/Logger";
+
+const logger = new Logger("getSigningCertificate.ts");
 
 export default async function getSigningCertificate(
   sender: MessageSender,
@@ -24,14 +27,16 @@ export default async function getSigningCertificate(
   userInteractionTimeout: number,
   lang?: string,
 ): Promise<ExtensionGetSigningCertificateResponse | ExtensionFailureResponse> {
+  logger.tabId = sender.tab?.id;
+
+  logger.log("Certificate requested");
+
   let nativeAppService: NativeAppService | undefined;
   let nativeAppStatus: { version: string } | undefined;
 
   try {
-    nativeAppService = new NativeAppService();
+    nativeAppService = new NativeAppService(sender.tab?.id);
     nativeAppStatus = await nativeAppService.connect();
-
-    config.DEBUG && console.log("getSigningCertificate: connected to native", nativeAppStatus);
 
     const message: NativeGetSigningCertificateRequest = {
       command: "get-signing-certificate",
@@ -55,12 +60,17 @@ export default async function getSigningCertificate(
     );
 
     if (isResponseValid) {
+      logger.info("Returning success response");
+
       return { action: Action.GET_SIGNING_CERTIFICATE_SUCCESS, ...response };
     } else {
+      logger.info("Certificate response is invalid");
+
       throw new UnknownError("unexpected response from native application");
     }
   } catch (error: any) {
-    console.error("GetSigningCertificate:", error);
+    logger.info("Certificate request failed");
+    logger.error(error);
 
     return actionErrorHandler(Action.GET_SIGNING_CERTIFICATE_FAILURE, error, libraryVersion, nativeAppStatus?.version);
   } finally {

--- a/src/background/actions/sign.ts
+++ b/src/background/actions/sign.ts
@@ -15,9 +15,11 @@ import UserTimeoutError from "@web-eid.js/errors/UserTimeoutError";
 import { MessageSender } from "../../models/Browser/Runtime";
 import NativeAppService from "../services/NativeAppService";
 import actionErrorHandler from "../../shared/actionErrorHandler";
-import config from "../../config";
 import { getSenderUrl } from "../../shared/utils/sender";
 
+import Logger from "../../shared/Logger";
+
+const logger = new Logger("sign.ts");
 
 export default async function sign(
   certificate: string,
@@ -28,14 +30,16 @@ export default async function sign(
   userInteractionTimeout: number,
   lang?: string,
 ): Promise<ExtensionSignResponse | ExtensionFailureResponse> {
+  logger.tabId = sender.tab?.id;
+
+  logger.log("Signing requested");
+
   let nativeAppService: NativeAppService | undefined;
   let nativeAppStatus: { version: string } | undefined;
 
   try {
-    nativeAppService = new NativeAppService();
+    nativeAppService = new NativeAppService(sender.tab?.id);
     nativeAppStatus  = await nativeAppService.connect();
-
-    config.DEBUG && console.log("Sign: connected to native", nativeAppStatus);
 
     const message: NativeSignRequest = {
       command: "sign",
@@ -65,12 +69,17 @@ export default async function sign(
     );
 
     if (isResponseValid) {
+      logger.info("Returning success response");
+
       return { action: Action.SIGN_SUCCESS, ...response };
     } else {
+      logger.info("Signing response is invalid");
+
       throw new UnknownError("unexpected response from native application");
     }
   } catch (error) {
-    console.error("Sign:", error);
+    logger.info("Signing failed");
+    logger.error(error);
 
     return actionErrorHandler(Action.SIGN_FAILURE, error, libraryVersion, nativeAppStatus?.version);
   } finally {

--- a/src/background/actions/status.ts
+++ b/src/background/actions/status.ts
@@ -12,16 +12,24 @@ import UnknownError from "@web-eid.js/errors/UnknownError";
 import VersionMismatchError from "@web-eid.js/errors/VersionMismatchError";
 import { serializeError } from "@web-eid.js/utils/errorSerializer";
 
+import { MessageSender } from "../../models/Browser/Runtime";
 import NativeAppService from "../services/NativeAppService";
 import checkCompatibility from "../../shared/utils/checkCompatibility";
-import config from "../../config";
+import { config } from "../../shared/configManager";
 
-export default async function status(libraryVersion: string): Promise<ExtensionStatusResponse | ExtensionFailureResponse> {
+import Logger from "../../shared/Logger";
+
+const logger = new Logger("status.ts");
+
+export default async function status(sender: MessageSender, libraryVersion: string): Promise<ExtensionStatusResponse | ExtensionFailureResponse> {
+  logger.tabId = sender.tab?.id;
+
+  logger.log("Status requested");
+
   const extensionVersion = config.VERSION;
-  const nativeAppService = new NativeAppService();
+  const nativeAppService = new NativeAppService(sender.tab?.id);
 
   try {
-
     const status = await nativeAppService.connect();
 
     const nativeApp = (
@@ -29,6 +37,8 @@ export default async function status(libraryVersion: string): Promise<ExtensionS
         ? status.version.substring(1)
         : status.version
     );
+
+    logger.info("Closing native app by sending the 'quit' command");
 
     await nativeAppService.send(
       { command: "quit", arguments: {} },
@@ -45,9 +55,13 @@ export default async function status(libraryVersion: string): Promise<ExtensionS
 
     const requiresUpdate = checkCompatibility(componentVersions);
 
+    logger.info("Checking requiresUpdate", requiresUpdate);
+
     if (requiresUpdate.extension || requiresUpdate.nativeApp) {
       throw new VersionMismatchError(undefined, componentVersions, requiresUpdate);
     }
+
+    logger.info("Returning success response");
 
     return {
       action: Action.STATUS_SUCCESS,
@@ -55,9 +69,10 @@ export default async function status(libraryVersion: string): Promise<ExtensionS
       ...componentVersions,
     };
   } catch (error: any) {
-    error.extension = extensionVersion;
+    logger.info("Status check failed");
+    logger.error(error);
 
-    console.error("Status:", error);
+    error.extension = extensionVersion;
 
     return {
       action: Action.STATUS_FAILURE,

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -13,6 +13,8 @@ import getSigningCertificate from "./actions/getSigningCertificate";
 import sign from "./actions/sign";
 import status from "./actions/status";
 
+import Logger from "../shared/Logger";
+
 async function onAction(message: ExtensionRequest, sender: MessageSender): Promise<void | object> {
   switch (message.action) {
     case Action.AUTHENTICATE:
@@ -47,6 +49,7 @@ async function onAction(message: ExtensionRequest, sender: MessageSender): Promi
 
     case Action.STATUS:
       return await status(
+        sender,
         message.libraryVersion,
       );
   }
@@ -58,12 +61,14 @@ async function onTokenSigningAction(message: TokenSigningMessage, sender: Messag
   switch (message.type) {
     case "VERSION": {
       return await TokenSigningAction.status(
+        sender,
         message.nonce,
       );
     }
 
     case "CERT": {
       return await TokenSigningAction.getCertificate(
+        sender,
         message.nonce,
         sender.url,
         message.lang,
@@ -73,6 +78,7 @@ async function onTokenSigningAction(message: TokenSigningMessage, sender: Messag
 
     case "SIGN": {
       return await TokenSigningAction.sign(
+        sender,
         message.nonce,
         sender.url,
         message.cert,
@@ -85,10 +91,35 @@ async function onTokenSigningAction(message: TokenSigningMessage, sender: Messag
 }
 
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  const logger = new Logger("background.ts");
+
+  logger.tabId = sender.tab?.id;
+
   if ((message as ExtensionRequest).action) {
-    onAction(message, sender).then(sendResponse);
+    logger.devToolsEvent("request", "Extension (content)", "Extension (background)", message);
+
+    onAction(message, sender)
+      .then((response) => {
+        logger.devToolsEvent("response", "Extension (content)", "Extension (background)", response);
+
+        return response;
+      })
+      .then(sendResponse);
+
+  } else if (message.devtools) {
+    logger.devToolsProxy(message, sender);
+    sendResponse();
   } else if ((message as TokenSigningMessage).type) {
-    onTokenSigningAction(message, sender).then(sendResponse);
+    logger.devToolsEvent("request", "Extension (content)", "Extension (background)", message);
+
+    onTokenSigningAction(message, sender)
+      .then((response) => {
+        logger.devToolsEvent("response", "Extension (content)", "Extension (background)", response);
+
+        return response;
+      })
+      .then(sendResponse);
   }
+
   return true;
 });

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -14,6 +14,9 @@ import sign from "./actions/sign";
 import status from "./actions/status";
 
 import Logger from "../shared/Logger";
+import { loadConfigFromStorage } from "../shared/configManager";
+
+const configLoaded = loadConfigFromStorage();
 
 async function onAction(message: ExtensionRequest, sender: MessageSender): Promise<void | object> {
   switch (message.action) {
@@ -96,11 +99,13 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   logger.tabId = sender.tab?.id;
 
   if ((message as ExtensionRequest).action) {
-    logger.devToolsEvent("request", "Extension (content)", "Extension (background)", message);
+    // Fire-and-forget: DevTools logging must not block message handling, using void to ignore Promise is the standard solution.
+    void logger.devToolsEvent("request", "Extension (content)", "Extension (background)", message);
 
-    onAction(message, sender)
+    void configLoaded
+      .then(() => onAction(message, sender))
       .then((response) => {
-        logger.devToolsEvent("response", "Extension (content)", "Extension (background)", response);
+        void logger.devToolsEvent("response", "Extension (content)", "Extension (background)", response);
 
         return response;
       })
@@ -110,11 +115,12 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     logger.devToolsProxy(message, sender);
     sendResponse();
   } else if ((message as TokenSigningMessage).type) {
-    logger.devToolsEvent("request", "Extension (content)", "Extension (background)", message);
+    void logger.devToolsEvent("request", "Extension (content)", "Extension (background)", message);
 
-    onTokenSigningAction(message, sender)
+    void configLoaded
+      .then(() => onTokenSigningAction(message, sender))
       .then((response) => {
-        logger.devToolsEvent("response", "Extension (content)", "Extension (background)", response);
+        void logger.devToolsEvent("response", "Extension (content)", "Extension (background)", response);
 
         return response;
       })

--- a/src/background/services/NativeAppService.ts
+++ b/src/background/services/NativeAppService.ts
@@ -8,7 +8,12 @@ import libraryConfig from "@web-eid.js/config";
 import { NativeRequest } from "@web-eid.js/models/message/NativeRequest";
 import { Port } from "../../models/Browser/Runtime";
 import calculateJsonSize from "../../shared/utils/calculateJsonSize";
-import config from "../../config";
+import { config } from "../../shared/configManager";
+
+import Logger from "../../shared/Logger";
+import isLoopbackAddress from "../../shared/utils/isLoopbackAddress";
+
+const logger = new Logger("NativeAppService.ts");
 
 export enum NativeAppState {
   UNINITIALIZED,
@@ -22,7 +27,13 @@ export default class NativeAppService {
 
   private port: Port | null = null;
 
+  constructor(tabId?: number) {
+    logger.tabId = tabId;
+  }
+
   async connect(): Promise<{ version: string }> {
+    logger.log("Connecting to the native application " + config.NATIVE_APP_NAME);
+
     this.state = NativeAppState.CONNECTING;
     this.port  = browser.runtime.connectNative(config.NATIVE_APP_NAME);
 
@@ -39,6 +50,8 @@ export default class NativeAppService {
       if (message.version) {
         this.state = NativeAppState.CONNECTED;
 
+        logger.info("Connected to the native application");
+
         return message;
       }
 
@@ -53,7 +66,7 @@ export default class NativeAppService {
       }
     } catch (error) {
       if (this.port.error) {
-        console.error(this.port.error);
+        logger.error(this.port.error);
       }
 
       if (error instanceof Error) {
@@ -67,7 +80,7 @@ export default class NativeAppService {
   }
 
   disconnectListener(): void {
-    config.DEBUG && console.log("Native app disconnected.");
+    logger.log("Native app disconnected.");
 
     // Accessing lastError when it exists stops chrome from throwing it unnecessarily.
     chrome?.runtime?.lastError;
@@ -76,36 +89,55 @@ export default class NativeAppService {
   }
 
   close(): void {
-    if (this.state == NativeAppState.DISCONNECTED) return;
+    logger.log("Closing connection to native application");
+
+    if (this.state == NativeAppState.DISCONNECTED) {
+      logger.info("Connection already closed");
+
+      return;
+    }
 
     this.state = NativeAppState.DISCONNECTED;
     this.port?.disconnect();
-
-    config.DEBUG && console.log("Native app port closed by extension.");
   }
 
   async send<T>(message: NativeRequest, timeout: number, throwAfterTimeout: Error): Promise<T> {
     switch (this.state) {
       case NativeAppState.CONNECTED: {
-        config.DEBUG && console.log("Sending message to native app", JSON.stringify(message));
-
         const messageSize = calculateJsonSize(message);
+
+        logger.debug("Calculated message size", messageSize);
 
         if (messageSize > config.NATIVE_MESSAGE_MAX_BYTES) {
           throw new Error(`native application message exceeded ${config.NATIVE_MESSAGE_MAX_BYTES} bytes`);
         }
+
+        if (config.ALLOW_HTTP_LOCALHOST && message.arguments?.origin) {
+          const url = new URL(message.arguments.origin);
+
+          if (url.protocol === "http:" && isLoopbackAddress(url.hostname)) {
+            url.protocol = "https:";
+
+            message.arguments.origin = url.origin;
+            logger.warn("Setting ALLOW_HTTP_LOCALHOST enabled, replaced origin with " + message.arguments.origin);
+          }
+        }
+
+        logger.log("Sending message to native application");
+        logger.devToolsEvent("request", "Extension (background)", "Native app", message);
 
         this.port?.postMessage(message);
 
         try {
           const response = await this.nextMessage(timeout, throwAfterTimeout);
 
+          logger.log("Response from native application");
+          logger.devToolsEvent("response", "Extension (background)", "Native app", response);
+
           this.close();
 
           return response;
         } catch (error) {
-          console.error(error);
-
           this.close();
 
           throw error;
@@ -154,9 +186,7 @@ export default class NativeAppService {
 
       const onDisconnectListener = (): void => {
         cleanup?.();
-        reject(new NativeUnavailableError(
-          "a message from native application was expected, but native application closed connection"
-        ));
+        reject(new NativeUnavailableError("connection to the native app was closed"));
       };
 
       cleanup = (): void => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,10 +13,29 @@ export default Object.freeze({
    */
   NATIVE_GRACEFUL_DISCONNECT_TIMEOUT: 2000, // 2 seconds
 
-  // Default: false
+  /**
+   * Web eID is able to provide Chrome Token Signing backwards compatibility.
+   * When enabled, in addition to the Web eID library, the Web eID browser extension will process hwcrypto.js events.
+   *
+   * In this mode, Web-eID will need to inject the Token Signing page script to websites.
+   *
+   * This is a temporary solution. Web eID library should be used instead of hwcrypto.js.
+   *
+   * Enabled by default.
+   *
+   * @see https://github.com/open-eid/chrome-token-signing
+   * @see https://github.com/hwcrypto/hwcrypto.js/wiki
+   */
   TOKEN_SIGNING_BACKWARDS_COMPATIBILITY:  process.env.TOKEN_SIGNING_BACKWARDS_COMPATIBILITY?.toUpperCase() === "TRUE",
   TOKEN_SIGNING_USER_INTERACTION_TIMEOUT: 1000 * 60 * 5, // 5 minutes
 
-  // Default: false
-  DEBUG: process.env.DEBUG?.toUpperCase() === "TRUE",
+  /**
+   * Should the Web eID extension allow http://localhost.
+   *
+   * The extension checks if the browser context is secure and the native application checks for the HTTPS protocol.
+   * Localhost is considered to be secure context, even when HTTPS is not used.
+   *
+   * When this option is enabled, the extension reports localhost URLs to the native application with HTTPS.
+   */
+  ALLOW_HTTP_LOCALHOST: false as boolean,
 });

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -9,10 +9,27 @@ import config from "../config";
 import injectPageScript from "./TokenSigning/injectPageScript";
 import tokenSigningResponse from "../shared/tokenSigningResponse";
 
+import Logger from "../shared/Logger";
+
+const logger = new Logger("content.ts", { isContentScript: true });
+
 function isWebeidEvent(event: MessageEvent): boolean {
   return (
     event.source === window &&
     event.data?.action?.startsWith?.("web-eid:")
+  );
+}
+
+function isWebeidResponseEvent(event: MessageEvent): boolean {
+  return (
+    event.source === window &&
+    event.data?.action?.startsWith?.("web-eid:") &&
+    (
+      event.data.action == Action.WARNING    ||
+      event.data.action.endsWith("-success") ||
+      event.data.action.endsWith("-failure") ||
+      event.data.action.endsWith("-ack")
+    )
   );
 }
 
@@ -29,13 +46,21 @@ async function send(message: object): Promise<object | void> {
   return response;
 }
 
+async function ack(
+  action: Action.AUTHENTICATE_ACK | Action.GET_SIGNING_CERTIFICATE_ACK | Action.SIGN_ACK | Action.STATUS_ACK,
+  origin: string
+): Promise<void> {
+  const message = { action };
+
+  await logger.devToolsEvent("response", "Website", "Extension (content)", message);
+  window.postMessage(message, origin);
+}
+
 window.addEventListener("message", async (event) => {
   if (isWebeidEvent(event)) {
-    // Warning messages should be ignored.
-    // When there are deprecation warnings, these messages would be sent by the content script and handled by the Web-eID library.
-    if (event.data.action === Action.WARNING) return;
+    if (isWebeidResponseEvent(event)) return;
 
-    config.DEBUG && console.log("Web-eID event: ", JSON.stringify(event));
+    logger.devToolsEvent("request", "Website", "Extension (content)", event.data);
 
     if (!window.isSecureContext) {
       const response = {
@@ -43,55 +68,60 @@ window.addEventListener("message", async (event) => {
         error:  new ContextInsecureError(),
       };
 
-      window.postMessage(response, event.origin);
+      logger.devToolsEvent("response", "Website", "Extension (content)", response);
 
+      window.postMessage(response, event.origin);
     } else {
       let response;
 
       switch (event.data.action) {
         case Action.STATUS: {
-          window.postMessage({ action: Action.STATUS_ACK }, event.origin);
+          await ack(Action.STATUS_ACK, event.origin);
           response = await send(event.data);
           break;
         }
 
         case Action.AUTHENTICATE: {
-          window.postMessage({ action: Action.AUTHENTICATE_ACK }, event.origin);
+          await ack(Action.AUTHENTICATE_ACK, event.origin);
           response = await send(event.data);
           break;
         }
 
         case Action.SIGN: {
-          window.postMessage({ action: Action.SIGN_ACK }, event.origin);
+          await ack(Action.SIGN_ACK, event.origin);
           response = await send(event.data);
           break;
         }
 
         case Action.GET_SIGNING_CERTIFICATE: {
-          window.postMessage({ action: Action.GET_SIGNING_CERTIFICATE_ACK }, event.origin);
+          await ack(Action.GET_SIGNING_CERTIFICATE_ACK, event.origin);
           response = await send(event.data);
           break;
         }
       }
 
       if (response) {
+        logger.devToolsEvent("response", "Website", "Extension (content)", response);
+
         window.postMessage(response, event.origin);
       }
     }
   } else if (config.TOKEN_SIGNING_BACKWARDS_COMPATIBILITY && isTokenSigningEvent(event)) {
-    config.DEBUG && console.log("TokenSigning event:", JSON.stringify(event));
+    logger.devToolsEvent("request", "Website", "Extension (content)", event.data);
 
     if (!window.isSecureContext) {
-      console.error(new ContextInsecureError());
+      logger.error(new ContextInsecureError());
 
       const nonce    = event.data.nonce;
       const response = tokenSigningResponse<TokenSigningErrorResponse>("technical_error", nonce);
+
+      logger.devToolsEvent("response", "Website", "Extension (content)", response);
 
       window.postMessage(response, event.origin);
     } else {
       const response = await send(event.data) as { warnings?: [], [key: string]: any } | void;
 
-      response?.warnings?.forEach((warning) => console.warn(warning));
+      logger.devToolsEvent("response", "Website", "Extension (content)", response);
 
       window.postMessage(response, event.origin);
     }

--- a/src/models/Browser.ts
+++ b/src/models/Browser.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Estonian Information System Authority
 // SPDX-License-Identifier: MIT
 
+import Devtools from "./Browser/Devtools";
+import ExtensionStorage from "./Browser/ExtensionStorage";
 import Permissions from "./Browser/Permissions";
 import Runtime from "./Browser/Runtime";
 import Tabs from "./Browser/Tabs";
@@ -38,4 +40,18 @@ export default interface Browser {
    * @see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs
    */
   tabs: Tabs;
+
+  /**
+   * Enables extensions to interact with the browser's Developer Tools.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools
+   */
+  devtools: Devtools;
+
+  /**
+   * Access the extension storage areas.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage
+   */
+  storage: ExtensionStorage;
 }

--- a/src/models/Browser/Devtools.ts
+++ b/src/models/Browser/Devtools.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+export default interface Devtools {
+
+  /**
+   * Interact with the window that Developer tools are attached to (inspected window).
+   * This includes obtaining the tab ID for the inspected page, evaluate the code
+   * in the context of the inspected window, reload the page, or obtain the list of resources within the page.
+   */
+  inspectedWindow: Window;
+
+  /**
+   * Obtain information about network requests associated with the window that
+   * the Developer Tools are attached to (the inspected window).
+   */
+  network: any;
+
+  /**
+   * Create User Interface panels that will be displayed inside User Agent Developer Tools.
+   */
+  panels: {
+    create: (title: string, iconPath: string, pagePath: string) => Promise<ExtensionPanel>;
+  };
+}
+
+export interface ExtensionPanel {
+  onShown:  {
+    addListener:    (listener: () => void) => void;
+    removeListener: (listener: () => void) => void;
+  };
+
+  onHidden: {
+    addListener:    (listener: () => void) => void;
+    removeListener: (listener: () => void) => void;
+  };
+}

--- a/src/models/Browser/ExtensionStorage.ts
+++ b/src/models/Browser/ExtensionStorage.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+export default interface ExtensionStorage {
+
+  /**
+   * Represents the local storage area. Items in local storage are local to the machine the extension was installed on.
+   */
+  local: StorageArea;
+
+  /**
+   * Represents the managed storage area. Items in managed storage are set by the domain administrator and
+   * are read-only for the extension. Trying to modify this namespace results in an error.
+   */
+  managed: StorageArea;
+
+  /**
+   * Represents the session storage area. Items in session storage are stored in memory and are not persisted to disk.
+   */
+  session: StorageArea;
+
+  /**
+   * Represents the sync storage area. Items in sync storage are synced by the browser,
+   * and are available across all instances of that browser that the user is logged into, across different devices.
+   */
+  sync: StorageArea;
+}
+
+export interface StorageArea {
+  /**
+   * Retrieves one or more items from the storage area.
+   */
+  get: (keys: null | string | object | Array<string>) => Promise<Record<string, any>>;
+
+  /**
+   * Gets the amount of storage space (in bytes) used for one or more items in the storage area.
+   */
+  getBytesInUse: (keys: null | string | Array<string>) => Promise<number>;
+  /**
+   * Stores one or more items in the storage area. If the item exists, its value is updated.
+   */
+  set: (data: Record<string, any>) => Promise<void>;
+  /**
+   * Removes one or more items from the storage area.
+   */
+  remove: (keys: string | Array<string>) => Promise<void>;
+  /**
+   * Removes all items from the storage area.
+   */
+  clear: () => Promise<void>;
+}

--- a/src/models/Browser/Runtime.ts
+++ b/src/models/Browser/Runtime.ts
@@ -10,10 +10,6 @@ export default interface Runtime {
    */
   id: string;
 
-  onMessage: {
-    addListener: (callback: OnMessageCallback) => void;
-  };
-
   /**
    * Sends a single message from an extension to a native application.
    *
@@ -88,6 +84,25 @@ export default interface Runtime {
    * Get the complete manifest.json file, deserialized from JSON to an object.
    */
   getManifest: () => any;
+
+  /**
+   * Fired when a connection is made with either an extension process or a content script.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onConnect
+   */
+  onConnect: {
+    addListener:    (listener: (port: Port) => void) => void;
+    removeListener: (listener: () => void) => void;
+  };
+
+  /**
+   * Use this event to listen for messages from another part of your extension.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
+   */
+  onMessage: {
+    addListener: (callback: OnMessageCallback) => void;
+  };
 }
 
 export interface Port {

--- a/src/models/Browser/Runtime.ts
+++ b/src/models/Browser/Runtime.ts
@@ -83,7 +83,7 @@ export default interface Runtime {
   /**
    * Get the complete manifest.json file, deserialized from JSON to an object.
    */
-  getManifest: () => any;
+  getManifest: () => Manifest;
 
   /**
    * Fired when a connection is made with either an extension process or a content script.
@@ -120,6 +120,12 @@ export interface Port {
   postMessage: (message: object) => void;
 
   sender?: any;
+}
+
+export interface Manifest {
+  manifest_version: number;
+  optional_permissions?: Array<string>;
+  permissions?: Array<string>;
 }
 
 export type OnMessageCallback = (message: any, sender: MessageSender, sendResponse?: any) => Promise<any> | void | boolean;

--- a/src/shared/Logger.ts
+++ b/src/shared/Logger.ts
@@ -39,31 +39,32 @@ export default class Logger {
 
   async log(...args: Array<any>): Promise<void> {
     await this.devToolsLog("log", args);
-    console.log(...args);
+    await this.consoleLog("log", args);
   }
 
   async info(...args: Array<any>): Promise<void> {
     await this.devToolsLog("info", args);
-    console.info(...args);
+    await this.consoleLog("info", args);
   }
 
   async warn(...args: Array<any>): Promise<void> {
     await this.devToolsLog("warn", args);
-    console.warn(...args);
+    await this.consoleLog("warn", args);
   }
 
   async error(...args: Array<any>): Promise<void> {
     await this.devToolsLog("error", args);
-    console.error(...args);
+    await this.consoleLog("error", args);
   }
 
   async debug(...args: Array<any>): Promise<void> {
     await this.devToolsLog("debug", args);
-    console.debug(...args);
+    await this.consoleLog("debug", args);
   }
 
   async isDevToolsEnabled(): Promise<boolean> {
-    const isOptionalPermissionDevToolsTurnedOn = Boolean(browser.runtime.getManifest().optional_permissions?.includes("devtools"));
+    const manifest                             = browser.runtime.getManifest();
+    const isOptionalPermissionDevToolsTurnedOn = Boolean(manifest.optional_permissions?.includes("devtools"));
 
     if (isOptionalPermissionDevToolsTurnedOn) {
       return true;
@@ -78,6 +79,32 @@ export default class Logger {
     }
 
     return false;
+  }
+
+  async isDebugEnabled(): Promise<boolean> {
+    if (this.isContentScript) {
+      return false;
+    }
+
+    try {
+      const isStorageEnabled = await isBrowserStorageEnabled();
+
+      if (isStorageEnabled) {
+        const { devtoolsEnabled } = await browser.storage.local.get(["devtoolsEnabled"]);
+
+        return Boolean(devtoolsEnabled);
+      }
+    } catch {
+      return false;
+    }
+
+    return false;
+  }
+
+  private async consoleLog(type: "log" | "info" | "warn" | "error" | "debug", args: Array<any>): Promise<void> {
+    if (await this.isDebugEnabled()) {
+      console[type](...args);
+    }
   }
 
   async devToolsLog(type: "event" | "log" | "info" | "warn" | "error" | "debug", rawMessage: Array<any>) {

--- a/src/shared/Logger.ts
+++ b/src/shared/Logger.ts
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+import { serializeError } from "@web-eid.js/utils/errorSerializer";
+
+import { MessageSender } from "../models/Browser/Runtime";
+import devToolsBridge from "./devToolsBridge";
+import isBrowserStorageEnabled from "./utils/isBrowserStorageEnabled";
+
+type Layer = "Website" | "Extension (content)" | "Extension (background)" | "Native app";
+
+interface DevToolsLogMessage {
+  devtools: "log";
+  source: string;
+  type: "log" | "info" | "warn" | "error";
+  message: string;
+  time: string;
+}
+
+interface DevToolsEventMessage {
+  devtools: "event";
+  type: "request" | "response";
+  layer1: Layer;
+  layer2: Layer;
+  data: any;
+  time: string;
+}
+
+export default class Logger {
+  private module: string;
+  private isContentScript = false;
+
+  public tabId?: number;
+
+  constructor(module: string, options?: { isContentScript: boolean }) {
+    this.module = module;
+    this.isContentScript = options?.isContentScript ?? this.isContentScript;
+  }
+
+  async log(...args: Array<any>): Promise<void> {
+    await this.devToolsLog("log", args);
+    console.log(...args);
+  }
+
+  async info(...args: Array<any>): Promise<void> {
+    await this.devToolsLog("info", args);
+    console.info(...args);
+  }
+
+  async warn(...args: Array<any>): Promise<void> {
+    await this.devToolsLog("warn", args);
+    console.warn(...args);
+  }
+
+  async error(...args: Array<any>): Promise<void> {
+    await this.devToolsLog("error", args);
+    console.error(...args);
+  }
+
+  async debug(...args: Array<any>): Promise<void> {
+    await this.devToolsLog("debug", args);
+    console.debug(...args);
+  }
+
+  async isDevToolsEnabled(): Promise<boolean> {
+    const isOptionalPermissionDevToolsTurnedOn = Boolean(browser.runtime.getManifest().optional_permissions?.includes("devtools"));
+
+    if (isOptionalPermissionDevToolsTurnedOn) {
+      return true;
+    }
+
+    const isStorageEnabled = await isBrowserStorageEnabled();
+
+    if (isStorageEnabled) {
+      const { devtoolsEnabled } = await browser.storage.local.get(["devtoolsEnabled"]);
+
+      return Boolean(devtoolsEnabled);
+    }
+
+    return false;
+  }
+
+  async devToolsLog(type: "event" | "log" | "info" | "warn" | "error" | "debug", rawMessage: Array<any>) {
+    if (this.isContentScript || await this.isDevToolsEnabled()) {
+      const time   = this.getCurrentTime();
+      const source = this.module;
+
+      const message = rawMessage.map((obj) => {
+        if (obj instanceof Error || obj.stack != null) {
+          return serializeError(obj);
+        } else {
+          return obj;
+        }
+      });
+
+      const devToolsLogMessage = {
+        devtools: "log",
+
+        source,
+        type,
+        message,
+        time,
+      };
+
+      if (this.isContentScript) {
+        browser.runtime.sendMessage(devToolsLogMessage);
+      } else {
+        devToolsBridge.send({ tabId: this.tabId, ...devToolsLogMessage });
+      }
+    }
+  }
+
+  async devToolsEvent(type: "request" | "response", layer1: Layer, layer2: Layer, data: any) {
+    if (this.isContentScript || await this.isDevToolsEnabled()) {
+      const time = this.getCurrentTime();
+
+      const devToolsEventMessage: DevToolsEventMessage = {
+        devtools: "event",
+
+        type,
+        data,
+        layer1,
+        layer2,
+        time,
+      };
+
+      if (this.isContentScript) {
+        browser.runtime.sendMessage(devToolsEventMessage);
+      } else {
+        devToolsBridge.send({ tabId: this.tabId, ...devToolsEventMessage });
+      }
+    }
+  }
+
+  devToolsProxy(
+    proxyMessage: DevToolsLogMessage | DevToolsEventMessage,
+    sender: MessageSender,
+  ) {
+    if (proxyMessage.devtools == "log") {
+      const { devtools, source, type, message, time } = proxyMessage;
+
+      devToolsBridge.send({
+        tabId: sender.tab?.id,
+
+        devtools,
+        source,
+        type,
+        message,
+        time,
+      });
+    } else if (proxyMessage.devtools == "event") {
+      const { devtools, type, data, layer1, layer2, time } = proxyMessage;
+
+      devToolsBridge.send({
+        tabId: sender.tab?.id,
+
+        devtools,
+        type,
+        data,
+        layer1,
+        layer2,
+        time
+      });
+    }
+  }
+
+  getCurrentTime() {
+    const now = new Date();
+    const [HH, mm, ss, SSS] = (
+      [
+        now.getHours(),
+        now.getMinutes(),
+        now.getSeconds(),
+        now.getMilliseconds(),
+      ]
+        .map((num) => num.toString())
+        .map((str, i) => str.padStart(i == 3 ? 3 : 2, "0"))
+    );
+
+    return `${HH}:${mm}:${ss}.${SSS}`;
+  }
+}

--- a/src/shared/__tests__/configManager-test.ts
+++ b/src/shared/__tests__/configManager-test.ts
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+import {config, setConfigOverride} from "../configManager";
+
+const mockStorageLocal = {
+  set: jest.fn(),
+  remove: jest.fn()
+};
+
+const mockBrowser = {
+  storage: {
+    local: mockStorageLocal
+  }
+};
+
+(global as any).browser = mockBrowser;
+
+const mockIsBrowserStorageEnabled = jest.fn();
+
+jest.mock("../utils/isBrowserStorageEnabled", () => ({
+  __esModule: true,
+  default: () => mockIsBrowserStorageEnabled()
+}));
+
+describe("setConfigOverride", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when storage is enabled", () => {
+    beforeEach(() => {
+      config.ALLOW_HTTP_LOCALHOST = false;
+      mockIsBrowserStorageEnabled.mockResolvedValue(true);
+    });
+
+    it("should set value in config and storage when value is not null", async () => {
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(false);
+
+      await setConfigOverride("ALLOW_HTTP_LOCALHOST", true);
+
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(true);
+      expect(mockStorageLocal.set).toHaveBeenCalledWith({ALLOW_HTTP_LOCALHOST: true});
+      expect(mockStorageLocal.remove).not.toHaveBeenCalled();
+    });
+
+    it("should set config value to default and remove key from storage when value is null", async () => {
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(false);
+
+      await setConfigOverride("ALLOW_HTTP_LOCALHOST", null);
+
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(false);
+      expect(mockStorageLocal.remove).toHaveBeenCalledWith(["ALLOW_HTTP_LOCALHOST"]);
+      expect(mockStorageLocal.set).not.toHaveBeenCalled();
+    });
+
+    it("should set config value to default and remove key from storage when value is equal to default value", async () => {
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(false);
+
+      await setConfigOverride("ALLOW_HTTP_LOCALHOST", false);
+
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(false);
+      expect(mockStorageLocal.remove).toHaveBeenCalledWith(["ALLOW_HTTP_LOCALHOST"]);
+      expect(mockStorageLocal.set).not.toHaveBeenCalled();
+    });
+
+    it("should not set non overridable config value", async () => {
+      expect(config.NATIVE_APP_NAME).toEqual("eu.webeid");
+
+      await setConfigOverride("NATIVE_APP_NAME", null);
+
+      expect(config.NATIVE_APP_NAME).toEqual("eu.webeid");
+      expect(mockStorageLocal.remove).not.toHaveBeenCalledWith(["NATIVE_APP_NAME"]);
+      expect(mockStorageLocal.set).not.toHaveBeenCalled();
+    });
+
+  });
+
+  describe("when storage is disabled", () => {
+    beforeEach(() => {
+      config.ALLOW_HTTP_LOCALHOST = false;
+      mockIsBrowserStorageEnabled.mockResolvedValue(false);
+    });
+
+    it("should set value in config and not call storage methods when storage is disabled", async () => {
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(false);
+
+      await setConfigOverride("ALLOW_HTTP_LOCALHOST", true);
+
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(true);
+      expect(mockStorageLocal.set).not.toHaveBeenCalled();
+      expect(mockStorageLocal.remove).not.toHaveBeenCalled();
+    });
+
+    it("should set config value to default and not call storage methods when storage is disabled", async () => {
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(false);
+
+      await setConfigOverride("ALLOW_HTTP_LOCALHOST", null);
+
+      expect(config.ALLOW_HTTP_LOCALHOST).toEqual(false);
+      expect(mockStorageLocal.set).not.toHaveBeenCalled();
+      expect(mockStorageLocal.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    beforeEach(() => {
+      mockIsBrowserStorageEnabled.mockResolvedValue(true);
+    });
+
+    it("should handle storage.set errors", async () => {
+      const error = new Error("Storage set failed");
+      mockStorageLocal.set.mockRejectedValue(error);
+
+      await expect(setConfigOverride("ALLOW_HTTP_LOCALHOST", true))
+        .rejects.toThrow("Storage set failed");
+    });
+
+    it("should handle storage.remove errors", async () => {
+      const error = new Error("Storage remove failed");
+      mockStorageLocal.remove.mockRejectedValue(error);
+
+      await expect(setConfigOverride("ALLOW_HTTP_LOCALHOST", null))
+        .rejects.toThrow("Storage remove failed");
+    });
+
+    it("should handle isBrowserStorageEnabled errors", async () => {
+      const error = new Error("Storage check failed");
+      mockIsBrowserStorageEnabled.mockRejectedValue(error);
+
+      await expect(setConfigOverride("ALLOW_HTTP_LOCALHOST", true))
+        .rejects.toThrow("Storage check failed");
+    });
+  });
+});

--- a/src/shared/__tests__/configManager-test.ts
+++ b/src/shared/__tests__/configManager-test.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Estonian Information System Authority
 // SPDX-License-Identifier: MIT
 
-import {config, setConfigOverride} from "../configManager";
+import {config, loadConfigFromStorage, setConfigOverride} from "../configManager";
 
 const mockStorageLocal = {
+  get: jest.fn(),
   set: jest.fn(),
   remove: jest.fn()
 };
@@ -25,7 +26,10 @@ jest.mock("../utils/isBrowserStorageEnabled", () => ({
 
 describe("setConfigOverride", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+    mockStorageLocal.get.mockResolvedValue({});
+    mockStorageLocal.set.mockResolvedValue(undefined);
+    mockStorageLocal.remove.mockResolvedValue(undefined);
   });
 
   describe("when storage is enabled", () => {
@@ -131,5 +135,63 @@ describe("setConfigOverride", () => {
       await expect(setConfigOverride("ALLOW_HTTP_LOCALHOST", true))
         .rejects.toThrow("Storage check failed");
     });
+  });
+});
+
+describe("loadConfigFromStorage", () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    config.ALLOW_HTTP_LOCALHOST = false;
+    config.NATIVE_MESSAGE_MAX_BYTES = 8192;
+    mockStorageLocal.get.mockResolvedValue({});
+    mockIsBrowserStorageEnabled.mockResolvedValue(true);
+    consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("should load valid stored override values into config", async () => {
+    mockStorageLocal.get.mockResolvedValue({
+      ALLOW_HTTP_LOCALHOST:    true,
+      NATIVE_MESSAGE_MAX_BYTES: 4096,
+    });
+
+    await loadConfigFromStorage();
+
+    expect(config.ALLOW_HTTP_LOCALHOST).toEqual(true);
+    expect(config.NATIVE_MESSAGE_MAX_BYTES).toEqual(4096);
+  });
+
+  it("should ignore stored values with invalid types", async () => {
+    mockStorageLocal.get.mockResolvedValue({
+      ALLOW_HTTP_LOCALHOST:    "true",
+      NATIVE_MESSAGE_MAX_BYTES: "4096",
+    });
+
+    await loadConfigFromStorage();
+
+    expect(config.ALLOW_HTTP_LOCALHOST).toEqual(false);
+    expect(config.NATIVE_MESSAGE_MAX_BYTES).toEqual(8192);
+  });
+
+  it("should not read storage when storage is disabled", async () => {
+    mockIsBrowserStorageEnabled.mockResolvedValue(false);
+
+    await loadConfigFromStorage();
+
+    expect(mockStorageLocal.get).not.toHaveBeenCalled();
+  });
+
+  it("should handle storage read errors", async () => {
+    const error = new Error("Storage get failed");
+    mockStorageLocal.get.mockRejectedValue(error);
+
+    await expect(loadConfigFromStorage()).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledWith("Failed to load configuration from storage:", error);
   });
 });

--- a/src/shared/actionErrorHandler.ts
+++ b/src/shared/actionErrorHandler.ts
@@ -8,7 +8,7 @@ import VersionMismatchError from "@web-eid.js/errors/VersionMismatchError";
 import { serializeError } from "@web-eid.js/utils/errorSerializer";
 
 import checkCompatibility from "./utils/checkCompatibility";
-import config from "../config";
+import { config } from "../shared/configManager";
 
 export default function actionErrorHandler(
   action:

--- a/src/shared/configManager.ts
+++ b/src/shared/configManager.ts
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+import defaultConfig from "../config";
+import isBrowserStorageEnabled from "./utils/isBrowserStorageEnabled";
+
+type Config = {
+  -readonly [key in keyof typeof defaultConfig]: typeof defaultConfig[key];
+};
+
+const config = JSON.parse(JSON.stringify(defaultConfig)) as Config;
+
+const overrideableConfigKeys: Array<keyof typeof defaultConfig> = [
+  "NATIVE_MESSAGE_MAX_BYTES",
+  "NATIVE_GRACEFUL_DISCONNECT_TIMEOUT",
+  "TOKEN_SIGNING_USER_INTERACTION_TIMEOUT",
+  "ALLOW_HTTP_LOCALHOST"
+];
+
+async function setConfigOverride<K extends keyof typeof defaultConfig>(key: K, value: typeof defaultConfig[K] | null) {
+  if (!overrideableConfigKeys.includes(key)) {
+    return;
+  }
+  setConfigValueOrResetToDefaultOnNull(key, value);
+  await saveToStorageOrRemoveOnNull(key, value);
+}
+
+async function loadConfigFromStorage() {
+  const isStorageEnabled = await isBrowserStorageEnabled();
+  if (isStorageEnabled) {
+    try {
+      const values = await browser.storage.local.get(overrideableConfigKeys);
+
+      for (const key of overrideableConfigKeys) {
+        if (isValidConfigValue(key, values[key])) {
+          setConfigValueOrResetToDefaultOnNull(key, values[key]);
+        }
+      }
+    } catch (error) {
+      console.error("Failed to load configuration from storage:", error);
+    }
+  }
+}
+
+function isValidConfigValue<K extends keyof typeof defaultConfig>(key: K, value: unknown): value is typeof defaultConfig[K] {
+  return typeof value === typeof defaultConfig[key];
+}
+
+function setConfigValueOrResetToDefaultOnNull<K extends keyof typeof defaultConfig>(key: K, value: typeof defaultConfig[K] | null) {
+  if (value === null) {
+    config[key] = defaultConfig[key];
+  } else {
+    config[key] = value;
+  }
+}
+
+async function saveToStorageOrRemoveOnNull<K extends keyof typeof defaultConfig>(key: K, value: typeof defaultConfig[K] | null) {
+  const isStorageEnabled = await isBrowserStorageEnabled();
+  if (isStorageEnabled) {
+    if (value === null || value === defaultConfig[key]) {
+      await browser.storage.local.remove([key]);
+    } else {
+      await browser.storage.local.set({ [key]: value });
+    }
+  }
+}
+
+export {
+  config,
+  defaultConfig,
+  loadConfigFromStorage,
+  setConfigOverride,
+};

--- a/src/shared/configManager.ts
+++ b/src/shared/configManager.ts
@@ -26,9 +26,9 @@ async function setConfigOverride<K extends keyof typeof defaultConfig>(key: K, v
 }
 
 async function loadConfigFromStorage() {
-  const isStorageEnabled = await isBrowserStorageEnabled();
-  if (isStorageEnabled) {
-    try {
+  try {
+    const isStorageEnabled = await isBrowserStorageEnabled();
+    if (isStorageEnabled) {
       const values = await browser.storage.local.get(overrideableConfigKeys);
 
       for (const key of overrideableConfigKeys) {
@@ -36,9 +36,9 @@ async function loadConfigFromStorage() {
           setConfigValueOrResetToDefaultOnNull(key, values[key]);
         }
       }
-    } catch (error) {
-      console.error("Failed to load configuration from storage:", error);
     }
+  } catch (error) {
+    console.error("Failed to load configuration from storage:", error);
   }
 }
 

--- a/src/shared/devToolsBridge.ts
+++ b/src/shared/devToolsBridge.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+import { config, defaultConfig, loadConfigFromStorage, setConfigOverride } from "./configManager";
+import { Port } from "../models/Browser/Runtime";
+
+class DevToolsBridge extends EventTarget {
+
+  devToolPorts: Array<Port> = [];
+
+  constructor() {
+    super();
+
+    browser.runtime.onConnect.addListener(async (port: Port) => {
+      await this.connectToPort(port);
+    });
+  }
+
+  send(message: object, options?: { ignore: Port }) {
+    this.devToolPorts
+      .filter((port) => !options?.ignore || port !== options.ignore)
+      .forEach((port) => port.postMessage(message));
+  }
+
+  private async connectToPort(port: Port) {
+    if (port.name === "webeid-devtools") {
+      this.devToolPorts.push(port);
+    }
+
+    port.onMessage.addListener((message) => {
+      if (message.devtools === "setting-set") {
+        setConfigOverride(message.key, message.value);
+
+        this.send({ devtools: "settings", config, defaultConfig }, { ignore: port });
+      }
+    });
+
+    port.onDisconnect.addListener(() => {
+      this.devToolPorts = this.devToolPorts.filter((connectedPort) => connectedPort !== port);
+    });
+
+    await loadConfigFromStorage();
+    port.postMessage({ devtools: "settings", config, defaultConfig });
+  }
+
+}
+
+export default new DevToolsBridge();

--- a/src/shared/tokenSigningResponse.ts
+++ b/src/shared/tokenSigningResponse.ts
@@ -6,7 +6,7 @@ import {
   TokenSigningResult,
 } from "../models/TokenSigning/TokenSigningResponse";
 
-import config from "../config";
+import { config } from "../shared/configManager";
 
 /**
  * Helper function to compose a token signing response message

--- a/src/shared/utils/__tests__/isBrowserStorageEnabled-test.ts
+++ b/src/shared/utils/__tests__/isBrowserStorageEnabled-test.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+import isBrowserStorageEnabled from "../isBrowserStorageEnabled";
+
+const mockPermissionsContains = jest.fn();
+const mockGetManifest = jest.fn();
+
+(global as any).browser = {
+  permissions: {
+    contains: mockPermissionsContains,
+  },
+  runtime: {
+    getManifest: mockGetManifest,
+  },
+};
+
+describe("isBrowserStorageEnabled", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should return true when storage is a required permission", async () => {
+    mockGetManifest.mockReturnValue({
+      permissions: ["storage"],
+    });
+
+    await expect(isBrowserStorageEnabled()).resolves.toEqual(true);
+
+    expect(mockPermissionsContains).not.toHaveBeenCalled();
+  });
+
+  it("should return true when optional storage permission has been granted", async () => {
+    mockGetManifest.mockReturnValue({
+      optional_permissions: ["storage"],
+    });
+    mockPermissionsContains.mockResolvedValue(true);
+
+    await expect(isBrowserStorageEnabled()).resolves.toEqual(true);
+  });
+
+  it("should return false when optional storage permission has not been granted", async () => {
+    mockGetManifest.mockReturnValue({
+      optional_permissions: ["storage"],
+    });
+    mockPermissionsContains.mockResolvedValue(false);
+
+    await expect(isBrowserStorageEnabled()).resolves.toEqual(false);
+  });
+
+  it("should return false when storage is not declared", async () => {
+    mockGetManifest.mockReturnValue({
+      permissions:          ["nativeMessaging"],
+      optional_permissions: ["devtools"],
+    });
+
+    await expect(isBrowserStorageEnabled()).resolves.toEqual(false);
+
+    expect(mockPermissionsContains).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/utils/__tests__/isLoopbackAddress-test.ts
+++ b/src/shared/utils/__tests__/isLoopbackAddress-test.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+import isLoopbackAddress from "../isLoopbackAddress";
+
+describe("isLoopbackAddress", () => {
+  it.each([
+    "localhost",
+    "127.0.0.1",
+    "127.255.255.255",
+    "[::1]",
+  ])("should detect %s as loopback", (host) => {
+    expect(isLoopbackAddress(host)).toEqual(true);
+  });
+
+  it.each([
+    "127.0.0.256",
+    "128.0.0.1",
+    "localhost.",
+    "foo.localhost",
+  ])("should not detect %s as loopback", (host) => {
+    expect(isLoopbackAddress(host)).toEqual(false);
+  });
+});

--- a/src/shared/utils/isBrowserStorageEnabled.ts
+++ b/src/shared/utils/isBrowserStorageEnabled.ts
@@ -4,10 +4,22 @@
 /**
  * Function to check if saving to browser storage is allowed
  *
- * @returns true if manifest optional_permissions includes storage and storage permission is given by user
+ * @returns true if storage is a required permission, or if optional storage has been granted by the user
  */
 export default async function isBrowserStorageEnabled() {
-  const isStorageOptional = Boolean(browser.runtime.getManifest().optional_permissions?.includes("storage"));
+  const manifest          = browser.runtime.getManifest();
+  const isStorageRequired = Boolean(manifest.permissions?.includes("storage"));
+
+  if (isStorageRequired) {
+    return true;
+  }
+
+  const isStorageOptional = Boolean(manifest.optional_permissions?.includes("storage"));
+
+  if (!isStorageOptional) {
+    return false;
+  }
+
   const hasStoragePermission = await browser.permissions.contains({ permissions: ["storage"] });
-  return isStorageOptional && hasStoragePermission;
+  return hasStoragePermission;
 }

--- a/src/shared/utils/isBrowserStorageEnabled.ts
+++ b/src/shared/utils/isBrowserStorageEnabled.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+/**
+ * Function to check if saving to browser storage is allowed
+ *
+ * @returns true if manifest optional_permissions includes storage and storage permission is given by user
+ */
+export default async function isBrowserStorageEnabled() {
+  const isStorageOptional = Boolean(browser.runtime.getManifest().optional_permissions?.includes("storage"));
+  const hasStoragePermission = await browser.permissions.contains({ permissions: ["storage"] });
+  return isStorageOptional && hasStoragePermission;
+}

--- a/src/shared/utils/isLoopbackAddress.ts
+++ b/src/shared/utils/isLoopbackAddress.ts
@@ -1,26 +1,18 @@
 // SPDX-FileCopyrightText: Estonian Information System Authority
 // SPDX-License-Identifier: MIT
 
-/**
- *
- * @param host hostname or ip address
- *
- * @returns true if is loopback address
- */
-
-const ipv4LoopbackAddressPattern = /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+const ipv4LoopbackAddressPattern = /^127\.(25[0-5]|2[0-4]\d|1?\d?\d)\.(25[0-5]|2[0-4]\d|1?\d?\d)\.(25[0-5]|2[0-4]\d|1?\d?\d)$/;
 
 /**
- * Checks whether host resolves to loopback address
+ * Checks whether a normalized URL hostname is a loopback host.
  *
- * @param host One of IP-literal / IPv4address / reg-name aka hostname
+ * @param host Normalized `URL.hostname`; IPv6 literals include brackets, e.g. `[::1]`.
  * @returns `true` if host is loopback address
  */
 export default function isLoopbackAddress(host: string): boolean {
   return (
     host === "localhost"                  ||
     ipv4LoopbackAddressPattern.test(host) ||
-    host === "[::1]"                      ||
-    host === "[0000:0000:0000:0000:0000:0000:0000:0001]"
+    host === "[::1]"
   );
 }

--- a/src/shared/utils/isLoopbackAddress.ts
+++ b/src/shared/utils/isLoopbackAddress.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+/**
+ *
+ * @param host hostname or ip address
+ *
+ * @returns true if is loopback address
+ */
+
+const ipv4LoopbackAddressPattern = /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+
+/**
+ * Checks whether host resolves to loopback address
+ *
+ * @param host One of IP-literal / IPv4address / reg-name aka hostname
+ * @returns `true` if host is loopback address
+ */
+export default function isLoopbackAddress(host: string): boolean {
+  return (
+    host === "localhost"                  ||
+    ipv4LoopbackAddressPattern.test(host) ||
+    host === "[::1]"                      ||
+    host === "[0000:0000:0000:0000:0000:0000:0000:0001]"
+  );
+}

--- a/static/chrome/manifest.json
+++ b/static/chrome/manifest.json
@@ -27,8 +27,15 @@
   "background": {
     "service_worker": "background.js"
   },
+  "options_ui": {
+    "page": "views/options.html"
+  },
+  "devtools_page": "views/devtools/devtools.html",
   "permissions": [
     "nativeMessaging"
+  ],
+  "optional_permissions": [
+    "storage"
   ],
   "host_permissions": [
     "*://*/*"

--- a/static/firefox/manifest.json
+++ b/static/firefox/manifest.json
@@ -33,8 +33,12 @@
       "background.js"
     ]
   },
+  "devtools_page": "views/devtools/devtools.html",
   "permissions": [
     "*://*/*",
     "nativeMessaging"
+  ],
+  "optional_permissions": [
+    "devtools"
   ]
 }

--- a/static/firefox/manifest.json
+++ b/static/firefox/manifest.json
@@ -36,7 +36,8 @@
   "devtools_page": "views/devtools/devtools.html",
   "permissions": [
     "*://*/*",
-    "nativeMessaging"
+    "nativeMessaging",
+    "storage"
   ],
   "optional_permissions": [
     "devtools"

--- a/static/firefox/manifest_v3.json
+++ b/static/firefox/manifest_v3.json
@@ -39,7 +39,8 @@
   },
   "devtools_page": "views/devtools/devtools.html",
   "permissions": [
-    "nativeMessaging"
+    "nativeMessaging",
+    "storage"
   ],
   "optional_permissions": [
     "devtools"

--- a/static/firefox/manifest_v3.json
+++ b/static/firefox/manifest_v3.json
@@ -37,8 +37,12 @@
       "background.js"
     ]
   },
+  "devtools_page": "views/devtools/devtools.html",
   "permissions": [
     "nativeMessaging"
+  ],
+  "optional_permissions": [
+    "devtools"
   ],
   "host_permissions": [
     "*://*/*"

--- a/static/safari/manifest.json
+++ b/static/safari/manifest.json
@@ -22,8 +22,16 @@
       "background.js"
     ]
   },
+  "options_ui": {
+    "page": "views/options.html"
+  },
+  "devtools_page": "views/devtools/devtools.html",
   "permissions": [
     "*://*/*",
     "nativeMessaging"
+  ],
+  "optional_permissions": [
+    "devtools",
+    "storage"
   ]
 }

--- a/static/safari/manifest_v3.json
+++ b/static/safari/manifest_v3.json
@@ -29,8 +29,12 @@
       "background.js"
     ]
   },
+  "devtools_page": "views/devtools/devtools.html",
   "permissions": [
     "nativeMessaging"
+  ],
+  "optional_permissions": [
+    "devtools"
   ],
   "host_permissions": [
     "*://*/*"

--- a/static/views/devtools/devtools.html
+++ b/static/views/devtools/devtools.html
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: Estonian Information System Authority -->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+</head>
+
+<body>
+  <script src="../browser-polyfill.min.js"></script>
+  <script src="devtools.js"></script>
+</body>
+
+</html>

--- a/static/views/devtools/devtools.js
+++ b/static/views/devtools/devtools.js
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Estonian Information System Authority
+
+async function isDevToolsEnabled() {
+  const isOptionalPermissionDevToolsTurnedOn = Boolean(browser.runtime.getManifest().optional_permissions?.includes("devtools"));
+
+  if (isOptionalPermissionDevToolsTurnedOn) {
+    return true;
+  }
+
+  const isStorageOptional    = Boolean(browser.runtime.getManifest().optional_permissions?.includes("storage"));
+  const hasStoragePermission = await browser.permissions.contains({ permissions: ["storage"] });
+
+  if (isStorageOptional && hasStoragePermission) {
+    const { devtoolsEnabled } = await browser.storage.local.get(["devtoolsEnabled"]);
+
+    return Boolean(devtoolsEnabled);
+  }
+
+  return false;
+}
+
+(async () => {
+  if (await isDevToolsEnabled()) {
+    browser.devtools.panels.create(
+      "Web eID",
+      "/icons/web-eid-icon-128.png",
+      "/views/devtools/panels/devtools-webeid.html",
+    );
+  }
+})();

--- a/static/views/devtools/panels/devtools-webeid.html
+++ b/static/views/devtools/panels/devtools-webeid.html
@@ -1,0 +1,98 @@
+<!-- SPDX-FileCopyrightText: Estonian Information System Authority -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Web-eID Privacy</title>
+  <link rel="stylesheet" href="../style/main.css">
+</head>
+
+<body>
+  <header>
+    <nav>
+      <input type="radio" name="page" id="nav-events" data-nav="events" checked>
+      <label for="nav-events">Events</label>
+
+      <input type="radio" name="page" id="nav-log" data-nav="log">
+      <label for="nav-log">Log</label>
+
+      <input type="radio" name="page" id="nav-settings" data-nav="settings">
+      <label for="nav-settings">Settings</label>
+    </nav>
+
+    <div class="version" title="Extension version"></div>
+  </header>
+
+  <main>
+    <section data-page="events">
+      <div id="event-list"></div>
+      <pre id="event-details"></pre>
+    </section>
+
+    <section data-page="log">
+      <div class="toolbar">
+        <div class="group">
+          <input type="button" value="Clear" id="clear-log">
+        </div>
+        <div class="group">
+          <span>Log levels:</span>
+          <label><input type="checkbox" data-logfilter="log" checked> Log</label>
+          <label><input type="checkbox" data-logfilter="warn" checked> Warning</label>
+          <label><input type="checkbox" data-logfilter="error" checked> Error</label>
+          <label><input type="checkbox" data-logfilter="info"> Info</label>
+          <label><input type="checkbox" data-logfilter="debug"> Debug</label>
+          <label><input type="checkbox" data-logfilter="event"> Event</label>
+        </div>
+      </div>
+      <div id="log-messages"></div>
+    </section>
+
+    <section data-page="settings">
+      <div class="warning">The settings you change here apply to all pages and persist even after closing DevTools.</div>
+      <table>
+        <tbody id="settings-list"></tbody>
+      </table>
+    </section>
+  </main>
+
+  <template id="event-template">
+    <div class="event">
+      <input type="radio" name="event">
+      <label>
+        <div>
+          <div class="layer-1"></div>
+          <div class="direction"></div>
+          <div class="layer-2"></div>
+        </div>
+        <div>
+          <div class="name"></div>
+          <div class="time"></div>
+        </div>
+      </label>
+    </div>
+  </template>
+
+  <template id="log-entry-template">
+    <div class="entry">
+      <pre class="time"></pre>
+      <pre class="message"></pre>
+      <pre class="source"></div>
+    </div>
+  </template>
+
+  <template id="setting-template">
+    <tr>
+      <th></th>
+      <td><input class="value" required></td>
+      <td><input class="reset" type="button" value="Reset"></td>
+    </tr>
+  </template>
+
+  <script src="../../browser-polyfill.min.js"></script>
+  <script type="module" src="devtools-webeid.js"></script>
+</body>
+
+</html>

--- a/static/views/devtools/panels/devtools-webeid.js
+++ b/static/views/devtools/panels/devtools-webeid.js
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+import events from "./webeid-events.js";
+import log from "./webeid-log.js";
+import settings from "./webeid-settings.js";
+
+const backgroundConnection = browser.runtime.connect({
+  name: "webeid-devtools",
+});
+
+const keepAliveInterval = setInterval(() => {
+  backgroundConnection.postMessage({ devtools: "keep-alive" });
+}, 20000);
+
+backgroundConnection.onDisconnect.addListener(() => {
+  clearInterval(keepAliveInterval);
+
+  log.append({
+    source: "devtools-webeid.js",
+    type: "error",
+    time: new Date().toISOString().match(/T((.)*)Z/)[1],
+    message: [
+      "Web eID DevTools panel disconnected from the extension. Please reopen the browser DevTools to continue."
+    ],
+  });
+});
+
+backgroundConnection.onMessage.addListener((message) => {
+  if (!message.tabId || message.tabId === browser.devtools.inspectedWindow.tabId || browser.devtools.inspectedWindow.tabId === -1) {
+    if (message.devtools === "log") {
+      log.append(message);
+
+    } else if (message.devtools === "event") {
+      events.append(message);
+
+      const direction = (
+        message.type === "request"
+          ? "—►"
+          : message.type === "response"
+            ? "◄—"
+            : "?"
+      );
+
+      log.append({
+        time:    message.time,
+        type:    "event",
+        source:  `${message.layer1} ${direction} ${message.layer2}`,
+        message: [message.data],
+      });
+    } else if (message.devtools === "settings") {
+      const { config, defaultConfig } = message;
+
+      settings.render(config, defaultConfig, backgroundConnection);
+
+      document.querySelector('header .version').textContent = defaultConfig.VERSION;
+    }
+  }
+});

--- a/static/views/devtools/panels/webeid-events.js
+++ b/static/views/devtools/panels/webeid-events.js
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+const ui = {
+  eventTemplate: document.querySelector("#event-template"),
+  eventList:     document.querySelector("section[data-page='events'] #event-list"),
+  eventDetails:  document.querySelector("section[data-page='events'] #event-details"),
+  clearButton:   document.querySelector("section[data-page='events'] #clear-events"),
+};
+
+function createEventElement(layer1, layer2, type, time, name, data) {
+  const root = ui.eventTemplate.content.cloneNode(true);
+
+  const el = {
+    event:     root.querySelector(".event"),
+    input:     root.querySelector("input"),
+    label:     root.querySelector("label"),
+    layer1:    root.querySelector(".layer-1"),
+    layer2:    root.querySelector(".layer-2"),
+    direction: root.querySelector(".direction"),
+    time:      root.querySelector(".time"),
+    name:      root.querySelector(".name"),
+  };
+
+  el.label.dataset.indent = ({
+    "Extension (content)":    1,
+    "Extension (background)": 2,
+    "Native app":             3,
+  })[layer1] ?? 0;
+
+  el.input.id      = "event-" + Math.random().toString(36).substring(2);
+  el.label.htmlFor = el.input.id;
+
+  el.layer1.textContent = layer1;
+  el.layer2.textContent = layer2;
+  el.time.textContent   = time;
+  el.name.textContent   = name;
+
+  el.direction.textContent = (
+    type === "request"
+      ? "—►"
+      : type === "response"
+        ? "◄—"
+        : ""
+  );
+
+  if (type === "response") {
+    el.label.dataset.responseType = name.split(/-|:/g).at(-1);
+  }
+
+  el.direction.dataset.type = type;
+
+  el.input.addEventListener("change", () => {
+    ui.eventDetails.textContent = JSON.stringify(data, null, "  ");
+  });
+
+  return el.event;
+}
+
+export default {
+  append({ layer1, layer2, type, time, data }) {
+    const name         = data.action ?? data.command ?? data.type ?? data.result ?? type;
+    const eventElement = createEventElement(layer1, layer2, type, time, name, data);
+
+    ui.eventList.appendChild(eventElement);
+  },
+};

--- a/static/views/devtools/panels/webeid-log.js
+++ b/static/views/devtools/panels/webeid-log.js
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+const ui = {
+  logEntryTemplate: document.querySelector("#log-entry-template"),
+  logContainer:     document.querySelector("section[data-page='log'] #log-messages"),
+  clearButton:      document.querySelector("section[data-page='log'] #clear-log"),
+};
+
+function createLogEntryElement(type, time, message, source) {
+  const root = ui.logEntryTemplate.content.cloneNode(true);
+
+  const el = {
+    entry:   root.querySelector(".entry"),
+    time:    root.querySelector(".time"),
+    message: root.querySelector(".message"),
+    source:  root.querySelector(".source" ),
+  };
+
+  el.entry.classList.add(`type-${type}`);
+
+  el.time.textContent    = time;
+  el.message.textContent = message;
+  el.source.textContent  = source;
+
+  return el.entry;
+}
+
+function stringifyError(error) {
+  const {
+    message,
+    name,
+    stack,
+  } = error;
+
+  const prettyStack = (
+    stack
+      .trim()
+      .split("\n")
+      .map((part) => "\t" + part)
+      .join("\n")
+  );
+
+  return `${name}: ${message}\n${prettyStack}`;
+}
+
+function stringifyMessageArray(message) {
+  return (
+    message
+      .map((obj) => {
+        if (typeof obj == "undefined") {
+          return "(undefined)";
+        } else if (obj == null) {
+          return "(null)";
+        } else if (obj instanceof Error || obj.stack != null) {
+          return stringifyError(obj);
+        } else if (obj instanceof Object) {
+          return JSON.stringify(obj, null, "  ");
+        } else {
+          return String(obj);
+        }
+      })
+      .join(", ")
+  );
+}
+
+ui.clearButton.addEventListener("click", () => {
+  [...ui.logContainer.children].forEach((child) => child.remove());
+});
+
+export default {
+  append({ time, type, message, source }) {
+    const { clientHeight, scrollHeight, scrollTop } = ui.logContainer;
+
+    const isScrolledToBottom = (scrollHeight - scrollTop) === clientHeight;
+    const messageString      = stringifyMessageArray(message);
+    const logEntryElement    = createLogEntryElement(type, time, messageString, source);
+
+    ui.logContainer.appendChild(logEntryElement);
+
+    if (isScrolledToBottom) {
+      ui.logContainer.scrollTo(0, ui.logContainer.scrollHeight);
+    }
+  },
+};

--- a/static/views/devtools/panels/webeid-settings.js
+++ b/static/views/devtools/panels/webeid-settings.js
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Estonian Information System Authority
+// SPDX-License-Identifier: MIT
+
+const includedSettings = [
+  "NATIVE_MESSAGE_MAX_BYTES",
+  "NATIVE_GRACEFUL_DISCONNECT_TIMEOUT",
+  "TOKEN_SIGNING_USER_INTERACTION_TIMEOUT",
+  "ALLOW_HTTP_LOCALHOST"
+];
+
+const ui = {
+  settingTemplate: document.querySelector("#setting-template"),
+  settingsTable:   document.querySelector("section[data-page='settings'] #settings-list")
+}
+
+export default {
+  render(config, defaultConfig, backgroundConnection) {
+    Object.assign(this, { config, defaultConfig, backgroundConnection });
+
+    const configRows = (
+      Object
+        .entries(config)
+        .filter(([key]) => this.isVisible(key))
+        .map(([key, value]) => this.createSettingRow(key, value))
+    );
+
+    ui.settingsTable.replaceChildren(...configRows);
+  },
+
+  isVisible(settingKey) {
+    return includedSettings.includes(settingKey);
+  },
+
+  createSettingRow(key, value) {
+    const row = ui.settingTemplate.content.cloneNode(true);
+
+    const el = {
+      key:   row.querySelector("th"),
+      input: row.querySelector("input.value"),
+      reset: row.querySelector("input.reset"),
+    };
+
+    el.key.innerText = key;
+
+    this.updateInput(el.input, value);
+    this.updateReset(el, key);
+
+    const changeEvent = (
+      el.input.type === "checkbox"
+        ? "change"
+        : "input"
+    );
+
+    el.input.addEventListener(changeEvent, () => {
+      const value = ({
+        "text":     el.input.value,
+        "number":   el.input.valueAsNumber,
+        "checkbox": el.input.checked
+      })[el.input.type];
+
+      this.backgroundConnection.postMessage({ devtools: 'setting-set', key, value });
+
+      this.config[key] = value;
+      this.updateReset(el, key);
+    });
+
+    el.reset.addEventListener("click", () => {
+      this.config[key] = this.defaultConfig[key];
+      el.reset.disabled = true;
+
+      this.backgroundConnection.postMessage({
+        devtools: 'setting-set',
+        key,
+        value: null,
+      });
+
+      this.updateInput(el.input, this.config[key]);
+    });
+
+    return row;
+  },
+
+  updateInput(input, value) {
+    switch (typeof value) {
+      case "number": {
+        input.type  = "number";
+        input.value = value;
+        break;
+      }
+
+      case "boolean": {
+        input.type = "checkbox";
+        input.checked = value;
+        break;
+      }
+
+      default:
+        input.type  = "text";
+        input.value = value;
+        break;
+    }
+  },
+
+  updateReset(el, key) {
+    el.reset.disabled = (
+      this.config[key] === this.defaultConfig[key]
+    );
+  }
+}

--- a/static/views/devtools/style/empty-element-messages.css
+++ b/static/views/devtools/style/empty-element-messages.css
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: MIT */
+/* SPDX-FileCopyrightText: Estonian Information System Authority */
+
+section[data-page="events"] #event-details:empty::before {
+  content: 'Select an event to inspect.';
+}
+
+section[data-page="events"] #event-list:empty::before {
+  content: 'The Web eID library has not sent any messages yet.';
+}

--- a/static/views/devtools/style/main.css
+++ b/static/views/devtools/style/main.css
@@ -1,0 +1,144 @@
+/* SPDX-License-Identifier: MIT */
+/* SPDX-FileCopyrightText: Estonian Information System Authority */
+
+@import url(theme.css);
+@import url(reset.css);
+@import url(page-events.css);
+@import url(page-log.css);
+@import url(page-settings.css);
+@import url(empty-element-messages.css);
+
+body {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+
+  font-family: var(--font-family);
+  color: var(--color-text-primary);
+  background: var(--color-background-primary);
+}
+
+input[type="button"] {
+  margin: 0;
+  padding: var(--spacing-s);
+  font-size: var(--font-size);
+  font-family: var(--font-family);
+
+  border: 1px solid var(--color-button-border);
+  color: var(--color-text-primary);
+  background-color: var(--color-background-primary);
+
+  &:hover:not(:disabled) {
+    background-color: var(--color-background-secondary);
+  }
+
+  &:active:not(:disabled) {
+    background-color: var(--color-background-tertiary);
+  }
+
+  &:disabled {
+    color: var(--color-button-border);
+  }
+}
+
+input[type="text"],
+input[type="number"] {
+  margin: 0;
+  padding: 0 var(--spacing-s);
+  border-radius: 2px;
+
+  border: 1px solid var(--color-input-border);
+  color: var(--color-text-primary);
+  background: var(--color-background-primary);
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+
+  gap: var(--spacing-m);
+  padding: 0 var(--spacing-m);
+
+  border: 1px solid var(--color-border);
+  background-color: var(--color-background-secondary);
+
+  nav {
+    font-size: var(--font-size);
+
+    flex: 0 0 auto;
+    display: flex;
+
+    input {
+      display: none;
+    }
+
+    label {
+      line-height: 2rem;
+      padding: 0 var(--spacing-m);
+
+      background-color: var(--color-background-secondary);
+      border-bottom: 0.125rem solid var(--color-tab-inactive);
+      transition: border-bottom-color var(--transition-duration) ease;
+    }
+
+    input:checked + label {
+      border-bottom: 2px solid var(--color-tab-active);
+    }
+  }
+
+  .version {
+    display: flex;
+    align-items: center;
+
+    font-family: var(--font-family-version);
+    font-size: var(--font-size-version);
+    color: var(--color-version);
+  }
+}
+
+body:not(:has([data-nav="events"]:checked)) [data-page="events"] {
+  display: none;
+}
+body:not(:has([data-nav="log"]:checked)) [data-page="log"] {
+  display: none;
+}
+body:not(:has([data-nav="settings"]:checked)) [data-page="settings"] {
+  display: none;
+}
+
+main {
+  position: relative;
+  flex: 1 1 100%;
+  overflow: hidden;
+
+  font-size: var(--font-size);
+
+  section {
+    height: 100%;
+
+    border: 1px solid var(--color-border);
+  }
+}
+
+.toolbar {
+  display: flex;
+  padding: var(--spacing-s) var(--spacing-m);
+
+  border: 1px solid var(--color-border);
+  background-color: var(--color-background-tertiary);
+
+  .group {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+    border-right: 1px solid var(--color-button-border);
+    padding-right: var(--spacing-m);
+    margin-right: var(--spacing-m);
+
+    label {
+      display: flex;
+      align-items: center;
+    }
+  }
+}

--- a/static/views/devtools/style/page-events.css
+++ b/static/views/devtools/style/page-events.css
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: MIT */
+/* SPDX-FileCopyrightText: Estonian Information System Authority */
+
+section[data-page="events"] {
+  display: flex;
+  gap: 0.125rem;
+
+  #event-list {
+    display: flex;
+    flex-direction: column;
+    flex: 0 0 40%;
+
+    border: 1px solid var(--color-border);
+
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    input {
+      display: none;
+    }
+
+    input:checked+label {
+      background-color: var(--color-event-background-active);
+      box-shadow: inset 0 0 0 1px var(--color-event-border-active);
+    }
+
+    label {
+      display: flex;
+      flex-direction: column;
+      padding: 0 var(--spacing-m);
+      border-bottom: 1px solid var(--color-border);
+      border-left: 0 solid var(--color-background-tertiary);
+      overflow: hidden;
+
+      &[data-indent="1"] { border-left-width: var(--spacing-m);           }
+      &[data-indent="2"] { border-left-width: calc(var(--spacing-m) * 2); }
+      &[data-indent="3"] { border-left-width: calc(var(--spacing-m) * 3); }
+
+      &[data-response-type="ack"]     { background-color: var(--color-event-ack);     }
+      &[data-response-type="success"] { background-color: var(--color-event-success); }
+      &[data-response-type="failure"] { background-color: var(--color-event-failure); }
+      &[data-response-type="warning"] { background-color: var(--color-event-warning); }
+
+      > div {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        height: 2rem;
+
+        &:first-child {
+          justify-content: flex-start;
+
+          color: color-mix(in srgb, currentcolor 75%, transparent);
+          border-bottom: 1px dotted var(--color-border);
+
+          .layer-1, .layer-2 {
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+
+          .layer-2 {
+            text-align: right;
+          }
+
+          .direction {
+            display: flex;
+            flex: 0 0 2rem;
+            justify-content: center;
+
+            &[data-type="request"] {
+              margin-right: auto;
+            }
+
+            &[data-type="response"] {
+              margin-left: auto;
+            }
+          }
+        }
+
+        &:last-child {
+          justify-content: space-between;
+        }
+      }
+
+      .time {
+        height: 1.5rem;
+        display: flex;
+        align-items: center;
+        padding: 0 var(--spacing-s);
+        border-radius: 0.125rem;
+
+        font-family: var(--font-family-timestamp);
+        font-size: var(--font-size-timestamp);
+        background-color: var(--color-background-tertiary);
+      }
+    }
+  }
+
+  #event-details {
+    flex: 1 1 auto;
+    overflow: auto;
+    border: 1px solid var(--color-border);
+
+    &:not(:empty) {
+      padding: var(--spacing-m);
+    }
+  }
+
+  #event-list:empty::before,
+  #event-details:empty::before {
+    display: block;
+    padding: var(--spacing-m);
+
+    color: var(--color-text-note);
+    font-family: var(--font-family);
+    font-size: var(--font-size);
+  }
+}

--- a/static/views/devtools/style/page-log.css
+++ b/static/views/devtools/style/page-log.css
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: MIT */
+/* SPDX-FileCopyrightText: Estonian Information System Authority */
+
+section[data-page="log"] {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  #log-messages {
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+
+    .entry {
+      display: flex;
+      padding: var(--spacing-m);
+      border: 1px dotted var(--color-border);
+
+      border-left: var(--spacing-m) solid color-mix(in srgb, var(--color-log-level-default) 50%, transparent);
+
+      &.type-info {
+        border-left-color: color-mix(in srgb, var(--color-log-level-info) 50%, transparent);
+        background-color: color-mix(in srgb, var(--color-log-level-info) 5%, transparent);
+      }
+
+      &.type-warn {
+        border-left-color: color-mix(in srgb, var(--color-log-level-warn) 50%, transparent);
+        background-color: color-mix(in srgb, var(--color-log-level-warn) 5%, transparent);
+      }
+
+      &.type-error {
+        border-left-color: color-mix(in srgb, var(--color-log-level-error) 50%, transparent);
+        background-color: color-mix(in srgb, var(--color-log-level-error) 5%, transparent);
+      }
+
+      &.type-event {
+        border-left-color: color-mix(in srgb, var(--color-log-level-event) 50%, transparent);
+        background-color: color-mix(in srgb, var(--color-log-level-event) 5%, transparent);
+      }
+
+      .time {
+        flex: 0 0 6rem;
+        color: var(--color-log-timestamp);
+      }
+
+      .message {
+        flex: 1 1 100%;
+        white-space: pre-wrap;
+      }
+
+      .source {
+        flex: 0 0 auto;
+        margin-left: var(--spacing-l);
+
+        color: var(--color-text-note);
+      }
+    }
+  }
+
+}
+
+body:not(:has([data-logfilter="log"]:checked))   #log-messages .entry.type-log   { display: none; }
+body:not(:has([data-logfilter="warn"]:checked))  #log-messages .entry.type-warn  { display: none; }
+body:not(:has([data-logfilter="error"]:checked)) #log-messages .entry.type-error { display: none; }
+body:not(:has([data-logfilter="info"]:checked))  #log-messages .entry.type-info  { display: none; }
+body:not(:has([data-logfilter="debug"]:checked)) #log-messages .entry.type-debug { display: none; }
+body:not(:has([data-logfilter="event"]:checked)) #log-messages .entry.type-event { display: none; }

--- a/static/views/devtools/style/page-settings.css
+++ b/static/views/devtools/style/page-settings.css
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: MIT */
+/* SPDX-FileCopyrightText: Estonian Information System Authority */
+
+section[data-page="settings"] {
+  overflow: auto;
+
+  .warning {
+    padding: var(--spacing-s);
+    background-color: color-mix(in srgb, var(--color-log-level-warn) 5%, transparent);
+  }
+
+  table {
+    width: 100%;
+
+    tr:first-child {
+      td, th {
+        border-top: 1px solid var(--color-border);
+      }
+    }
+
+    td, th {
+      border-bottom: 1px solid var(--color-border);
+      padding: var(--spacing-xs) var(--spacing-s);
+    }
+
+    th {
+      width: 1px;
+      text-align: left;
+    }
+
+    td:last-child {
+      text-align: right;
+    }
+  }
+
+  input:invalid {
+    background-color: var(--color-input-invalid);
+  }
+}

--- a/static/views/devtools/style/reset.css
+++ b/static/views/devtools/style/reset.css
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+/* SPDX-FileCopyrightText: Estonian Information System Authority */
+
+* {
+  box-sizing: border-box;
+}
+
+label {
+  user-select: none;
+}
+
+body, pre {
+  margin: 0;
+}

--- a/static/views/devtools/style/theme.css
+++ b/static/views/devtools/style/theme.css
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: MIT */
+/* SPDX-FileCopyrightText: Estonian Information System Authority */
+
+:root {
+  --spacing-xs: 0.125rem;
+  --spacing-s: 0.25rem;
+  --spacing-m: 0.5rem;
+  --spacing-l: 1rem;
+
+  --color-text-primary: #181818;
+  --color-text-note: #31313199;
+  --color-background-primary: #ffffff;
+  --color-background-secondary: #f3f3f3;
+  --color-background-tertiary: #eaeaea;
+  --color-border: #e8e8e8;
+
+  --color-tab-background: var(--color-background-secondary);
+  --color-tab-background-hover: var(--color-background-secondary);
+  --color-tab-inactive: transparent;
+  --color-tab-active: #1155cc;
+
+  --color-button-border: #d3d3d3;
+
+  --color-input-invalid: #ff000050;
+  --color-input-border: #31313199;
+
+  --color-event-border-active: color-mix(in srgb, var(--color-tab-active) 50%, var(--color-background-primary));
+  --color-event-background-active: color-mix(in srgb, var(--color-tab-active) 5%, var(--color-background-primary));
+
+  --event-highlight-strength: 5%;
+  --color-event-ack: color-mix(in srgb, teal var(--event-highlight-strength), var(--color-background-primary));
+  --color-event-success: color-mix(in srgb, lime var(--event-highlight-strength), var(--color-background-primary));
+  --color-event-failure: color-mix(in srgb, red var(--event-highlight-strength), var(--color-background-primary));
+  --color-event-warning: color-mix(in srgb, orange var(--event-highlight-strength), var(--color-background-primary));
+
+  --color-log-timestamp: #666;
+  --color-log-level-default: black;
+  --color-log-level-info: blue;
+  --color-log-level-warn: orange;
+  --color-log-level-error: red;
+  --color-log-level-event: yellow;
+
+  --font-family: sans-serif;
+  --font-size: 0.75rem;
+
+  --font-family-timestamp: monospace;
+  --font-size-timestamp: 0.625rem;
+
+  --font-family-version: monospace;
+  --font-size-version: 0.625rem;
+  --color-version: #666;
+
+  --transition-duration: 0.2s;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --event-highlight-strength: 10%;
+    --color-text-primary: #e7e7e7;
+    --color-text-note: #cecece99;
+    --color-background-primary: #334;
+    --color-background-secondary: #445;
+    --color-background-tertiary: #556;
+    --color-border: #171717;
+    --color-button-border: #5a5a5a;
+    --color-version: #aaa;
+  }
+}

--- a/static/views/options.html
+++ b/static/views/options.html
@@ -1,0 +1,88 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: Estonian Information System Authority -->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+
+    <script src="browser-polyfill.min.js"></script>
+
+    <style>
+      @media (prefers-color-scheme: dark) {
+        body {
+          color: #FFF;
+          background-color: #333;
+        }
+      }
+
+      body {
+        font-size: 16px;
+        margin: 1rem;
+        box-sizing: border-box;
+      }
+
+      main {
+        max-width: 320px;
+      }
+
+      .switch {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        > input[type="checkbox"]:checked {
+          --switch-check-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%22-4%20-4%208%208%22%3E%3Ccircle%20r%3D%223%22%20fill%3D%22white%22%20/%3E%3C/svg%3E");
+
+          background-position: right center;
+          background-color: #0061E0;
+          border-color: #0061E0;
+        }
+
+        > input[type="checkbox"] {
+          --switch-check-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%22-4%20-4%208%208%22%3E%3Ccircle%20r%3D%223%22%20fill%3D%22%2300000070%22%20/%3E%3C/svg%3E");
+
+          appearance: none;
+          background-image: var(--switch-check-image);
+          background-repeat: no-repeat;
+          background-position: left center;
+          background-color: #EDEDED;
+
+          box-sizing: border-box;
+          height: 1.2em;
+          width: 2.4em;
+
+          border: 1px solid #00000070;
+          border-radius: 2em;
+
+          transition: background-position 150ms ease-in-out;
+        }
+      }
+
+      .warning {
+        background: color-mix(in srgb, orange 5%, transparent);
+        margin: 0.5rem 0;
+        padding: 0.8rem;
+
+        font-size: 0.8rem;
+
+        &.storage-not-allowed,
+        &.open-devtools-again {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <main>
+      <div class="switch">
+        <label for="devtools">Enable developer tools</label>
+        <input type="checkbox" id="devtools">
+      </div>
+      <div class="warning storage-not-allowed">The extension needs storage permissions to persist the settings.</div>
+      <div class="warning open-devtools-again">For the "Web eID" tab to appear in the browser's DevTools, you will need to close an existing DevTools and reopen it.</div>
+    </main>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/static/views/options.js
+++ b/static/views/options.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Estonian Information System Authority
+
+const ui = {
+  devtools:          document.querySelector("#devtools"),
+  storageNotAllowed: document.querySelector(".warning.storage-not-allowed"),
+  openDevToolsAgain: document.querySelector(".warning.open-devtools-again"),
+
+};
+
+(async () => {
+  if (await browser.permissions.contains({ permissions: ["storage"] })) {
+    const { devtoolsEnabled } = await browser.storage.local.get(["devtoolsEnabled"]);
+
+    ui.devtools.checked = Boolean(devtoolsEnabled);
+  }
+})();
+
+ui.devtools.addEventListener("change", async () => {
+  const hasStoragePermission = await browser.permissions.request({
+    permissions: ["storage"]
+  });
+
+  if (!hasStoragePermission) {
+    ui.storageNotAllowed.style.display = 'block';
+  } else {
+    ui.storageNotAllowed.style.display = 'none';
+
+    browser.storage.local.set({ devtoolsEnabled: ui.devtools.checked });
+
+    ui.openDevToolsAgain.style.display = (
+      ui.devtools.checked
+        ? 'block'
+        : 'none'
+    );
+  }
+});


### PR DESCRIPTION
Adds the "Web eID" tab to the browser's DevTools.

**Features:**
- Event history between the website, extension and native application.
- Extension's internal log messages.
- Option to override extension settings, without needing to compile the extension yourself.
- Option to allow the http://localhost origin when authenticating and signing

The developer tool is disabled by default and needs to be enabled before it can be used.

**Firefox**
1. Open [Menu -> Settings -> Extensions and themes]  
   or navigate to the address `about:addons`
2. Open the Web eID extension details
3. Open the "Permissions" tab
4. Toggle "Extend developer tools to access your data in open tabs"

**Chrome**
1. Open [Settings -> Extensions]  
   or navigate to the address `chrome://extensions/`
2. Open the Web eID extension details
3. Open "Extension options"
4. Toggle "Enable developer tools"

**Screenshots:**  
Viewing event sequence and the event objects:  
![image](https://github.com/user-attachments/assets/928c28fe-09d9-4d59-a5e9-1613c82ca1ae)

Viewing the extension's internal log messages:
![image](https://github.com/user-attachments/assets/746db557-28d9-4914-a84f-0200ca09c767)

Overriding the extension settings:
![image](https://github.com/user-attachments/assets/685651ab-cd8e-4f66-a61a-097662db4ddf)

Resolves WE2-967
Resolves #40 

Signed-off-by: Tanel Metsar <taneltm@users.noreply.github.com>
